### PR TITLE
feat: add weekly dependency update workflow

### DIFF
--- a/.github/workflows/update-deps.yml
+++ b/.github/workflows/update-deps.yml
@@ -1,0 +1,80 @@
+---
+name: Weekly Dependency Update
+
+# Dependabot now supports updating direct dependencies in uv.lock
+# (see https://github.com/dependabot/dependabot-core/issues/10478),
+# but it cannot update transitive dependencies — aiohttp, cryptography,
+# Jinja2, etc. — in uv.lock. Those transitive deps account for most of
+# the open security advisories in this repo.
+# Track: https://github.com/dependabot/dependabot-core/issues/14073
+
+on:
+  schedule:
+    - cron: '0 3 * * 1'   # Monday 03:00 UTC
+  workflow_dispatch:
+
+jobs:
+  update-deps:
+    name: 🔒 Update dependencies
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - name: ⤵️ Checkout repository
+        uses: actions/checkout@v6
+
+      - name: 🛠️ Install uv
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b  # v8.1.0
+
+      - name: 🧹 Close previous dependency update PRs
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |-
+          for pr_number in $(gh pr list \
+            --state open \
+            --author "github-actions[bot]" \
+            --json number,title \
+            --jq '.[] | select(.title | startswith("chore: weekly dependency update")) | .number'); do
+            echo "Closing previous PR #$pr_number"
+            gh pr close "$pr_number" --delete-branch
+          done
+
+      - name: 🔒 Upgrade all dependencies
+        run: uv lock --upgrade
+
+      - name: ✅ Verify lockfile resolves
+        run: uv sync --all-extras --frozen
+
+      - name: 📝 Detect changes
+        id: diff
+        run: |-
+          if git diff --quiet uv.lock; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: 📤 Create Pull Request
+        if: steps.diff.outputs.changed == 'true'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |-
+          BRANCH="deps/weekly-update-$(date +%Y-%m-%d)"
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git checkout -b "$BRANCH"
+          git add uv.lock
+          git commit -m "chore: weekly dependency update"
+          git push origin "$BRANCH"
+          gh pr create \
+            --title "chore: weekly dependency update" \
+            --body "Automated weekly dependency update via \`uv lock --upgrade\`.
+
+              Dependabot handles direct dependency updates in \`uv.lock\` but cannot
+              update transitive dependencies. This PR covers the transitive gap.
+
+              See: https://github.com/dependabot/dependabot-core/issues/14073" \
+            --label dependencies \
+            --base main \
+            --head "$BRANCH"

--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,7 @@ shared_data/
 # Local workspace
 .env
 .env.backup
+.worktrees/
 
 # Package build artifacts
 *.egg


### PR DESCRIPTION
## 📋 Summary

- Adds a scheduled GitHub Actions workflow (`update-deps.yml`) that runs `uv lock --upgrade` every Monday at 03:00 UTC
- Closes any previous weekly dependency update PRs before creating a new one, ensuring at most one open PR at any time
- Creates a PR with the `dependencies` label if `uv.lock` changes; skips PR creation if nothing changed

## 🧠 Context

Dependabot now supports updating **direct** dependencies in `uv.lock` (see [dependabot/dependabot-core#10478](https://github.com/dependabot/dependabot-core/issues/10478)), but it **cannot update transitive dependencies** — aiohttp, cryptography, Jinja2, etc. Those transitive deps account for most of the 47 open security advisories in this repo.

This workflow closes that gap until Dependabot adds native `uv.lock` transitive support.

Track: [dependabot/dependabot-core#14073](https://github.com/dependabot/dependabot-core/issues/14073)

## ✅ Test Plan

- [x] Verify the workflow YAML passes `yamllint` (already confirmed via pre-commit hooks)
- [x] Trigger the workflow manually via `workflow_dispatch` and confirm it creates a PR if `uv.lock` changes
- [x] Confirm that re-running the workflow closes the previous PR before opening a new one
- [x] Confirm that if no deps change, no PR is created

## 📎 Also

- Added `.worktrees/` to `.gitignore` (project-local git worktree directory)