### PR TITLE
fix: use GitHub App token for PR creation in update-deps workflow

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -10,4 +10,4 @@ jobs:
     uses: HeadlessTarry/.github/.github/workflows/auto-merge.yml@ac623ad1fb30c673220bce68311c6e03be92c832
     permissions: {}
     secrets:
-      AUTO_APPROVAL_PRIVATE_KEY: ${{ secrets.AUTO_APPROVAL_PRIVATE_KEY }}
+      AUTO_PRS_PRIVATE_KEY: ${{ secrets.AUTO_PRS_PRIVATE_KEY }}

--- a/.github/workflows/update-deps.yml
+++ b/.github/workflows/update-deps.yml
@@ -21,19 +21,27 @@ jobs:
       contents: write
       pull-requests: write
     steps:
+      - name: 🔑 Authenticate
+        id: app-token
+        uses: actions/create-github-app-token@v3
+        with:
+          client-id: ${{ vars.AUTO_PRS_CLIENT_ID }}
+          private-key: ${{ secrets.AUTO_PRS_PRIVATE_KEY }}
+
       - name: ⤵️ Checkout repository
         uses: actions/checkout@v6
+        with:
+          token: ${{ steps.app-token.outputs.token }}
 
       - name: 🛠️ Install uv
         uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b  # v8.1.0
 
       - name: 🧹 Close previous dependency update PRs
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |-
           for pr_number in $(gh pr list \
             --state open \
-            --author "github-actions[bot]" \
             --json number,title \
             --jq '.[] | select(.title | startswith("chore: weekly dependency update")) | .number'); do
             echo "Closing previous PR #$pr_number"
@@ -58,7 +66,7 @@ jobs:
       - name: 📤 Create Pull Request
         if: steps.diff.outputs.changed == 'true'
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |-
           BRANCH="deps/weekly-update-$(date +%Y-%m-%d)"
           git config user.name "github-actions[bot]"


### PR DESCRIPTION
## Summary

- **update-deps.yml**: Use `actions/create-github-app-token@v3` with `vars.AUTO_PRS_CLIENT_ID` / `secrets.AUTO_PRS_PRIVATE_KEY` instead of `GITHUB_TOKEN`. This bypasses the repo-level setting that blocks `GITHUB_TOKEN` from creating PRs. Also removes `--author "github-actions[bot]"` filter from the PR cleanup step since PRs will now be authored by the App identity.
- **auto-merge.yml**: Rename `AUTO_APPROVAL_PRIVATE_KEY` → `AUTO_PRS_PRIVATE_KEY` to match the consolidated secret name.

## Test Plan

- [ ] Trigger the `update-deps.yml` workflow manually via `workflow_dispatch` and confirm it can create a PR
- [ ] Confirm the auto-merge workflow still works for Dependabot PRs with the renamed secret