### PR TITLE
chore: switch Dependabot to uv ecosystem and clarify workflow role

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,11 @@ updates:
     directory: /
     schedule:
       interval: weekly
+    cooldown:
+      default-days: 20
+      semver-patch-days: 10
+      semver-minor-days: 20
+      semver-major-days: 30
 
   - package-ecosystem: pre-commit
     directory: /

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,15 +1,10 @@
 ---
 version: 2
 updates:
-  - package-ecosystem: pip
+  - package-ecosystem: uv
     directory: /
     schedule:
       interval: weekly
-    cooldown:
-      default-days: 20
-      semver-patch-days: 10
-      semver-minor-days: 20
-      semver-major-days: 30
 
   - package-ecosystem: pre-commit
     directory: /

--- a/.github/workflows/update-deps.yml
+++ b/.github/workflows/update-deps.yml
@@ -1,12 +1,20 @@
 ---
-name: Weekly Dependency Update
+name: 🔒 Weekly Dependency Refresh
 
-# Dependabot now supports updating direct dependencies in uv.lock
-# (see https://github.com/dependabot/dependabot-core/issues/10478),
-# but it cannot update transitive dependencies — aiohttp, cryptography,
-# Jinja2, etc. — in uv.lock. Those transitive deps account for most of
-# the open security advisories in this repo.
-# Track: https://github.com/dependabot/dependabot-core/issues/14073
+# Complements Dependabot (uv ecosystem) which handles security PRs for direct
+# dependencies declared in pyproject.toml.
+#
+# Dependabot cannot update transitive dependencies when the parent dependency
+# constrains the version range (e.g. homeassistant pins aiohttp<3.12). This is
+# a known limitation — see https://github.com/dependabot/dependabot-core/issues/10478
+#
+# This workflow runs `uv lock --upgrade` to bump ALL dependencies (direct and
+# transitive) to their latest COMPATIBLE versions within existing constraints,
+# plus non-security housekeeping bumps that Dependabot would never raise.
+#
+# IMPORTANT: Neither Dependabot nor this workflow can push a transitive dep
+# beyond its parent's version upper bound. Resolving those vulnerabilities
+# requires upgrading the parent dependency (e.g. homeassistant-stubs).
 
 on: # yamllint disable-line rule:truthy
   schedule:
@@ -15,7 +23,7 @@ on: # yamllint disable-line rule:truthy
 
 jobs:
   update-deps:
-    name: 🔒 Update dependencies
+    name: 🔒 Refresh lockfile
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -36,19 +44,19 @@ jobs:
       - name: 🛠️ Install uv
         uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b  # v8.1.0
 
-      - name: 🧹 Close previous dependency update PRs
+      - name: 🧹 Close previous refresh PRs
         env:
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |-
           for pr_number in $(gh pr list \
             --state open \
             --json number,title \
-            --jq '.[] | select(.title | startswith("chore: weekly dependency update")) | .number'); do
+            --jq '.[] | select(.title | startswith("chore: weekly dependency refresh")) | .number'); do
             echo "Closing previous PR #$pr_number"
             gh pr close "$pr_number" --delete-branch
           done
 
-      - name: 🔒 Upgrade all dependencies
+      - name: 🔒 Upgrade all compatible dependencies
         run: uv lock --upgrade
 
       - name: ✅ Verify lockfile resolves
@@ -68,21 +76,29 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |-
-          BRANCH="deps/weekly-update-$(date +%Y-%m-%d)"
+          BRANCH="deps/weekly-refresh-$(date +%Y-%m-%d)"
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git checkout -b "$BRANCH"
           git add uv.lock
-          git commit -m "chore: weekly dependency update"
+          git commit -m "chore: weekly dependency refresh"
           git push --force origin "$BRANCH"
           gh pr create \
-            --title "chore: weekly dependency update" \
-            --body "Automated weekly dependency update via \`uv lock --upgrade\`.
+            --title "chore: weekly dependency refresh" \
+            --body "Weekly lockfile refresh via \`uv lock --upgrade\` — bumps all
+              dependencies to their latest compatible versions within existing
+              constraints.
 
-              Dependabot handles direct dependency updates in \`uv.lock\` but cannot
-              update transitive dependencies. This PR covers the transitive gap.
+              Dependabot (uv ecosystem) handles security PRs for direct dependencies.
+              This workflow covers:
 
-              See: https://github.com/dependabot/dependabot-core/issues/14073" \
+              - Transitive dependency bumps within parent-constrained ranges
+              - Non-security housekeeping updates Dependabot won't raise
+              - Keeping uv.lock fresh across all resolution markers
+
+              **Note:** Transitive deps pinned by a parent (e.g. aiohttp pinned by
+              homeassistant) cannot exceed the parent's version upper bound. Resolving
+              those vulnerabilities requires upgrading the parent dependency." \
             --label dependencies \
             --base main \
             --head "$BRANCH"


### PR DESCRIPTION
## 🔧 What changes

### 1. `.github/dependabot.yml` — Switch from `pip` to `uv` ecosystem

- Changed `package-ecosystem: pip` → `package-ecosystem: uv`
- Removed the cooldown settings (20–30 day delays). Since Dependabot for `uv` only creates security PRs for direct dependencies, delaying these by up to a month creates unnecessary risk with no benefit — direct deps in `pyproject.toml` already use `>=` minimum-version pins.

### 2. `.github/workflows/update-deps.yml` — Clarify complementary role

- Renamed from "Weekly Dependency Update" → "Weekly Dependency Refresh"
- Rewrote header comment to clearly explain the workflow's **supplementary** role alongside Dependabot (not replacing it)
- Key clarifications in the comment:
  - Dependabot (uv ecosystem) handles **security PRs for direct dependencies**
  - This workflow handles **compatible-version bumps for all deps** (both direct and transitive), plus non-security housekeeping
  - **Neither** can push a transitive dep beyond its parent's version upper bound — resolving those vulnerabilities requires upgrading the parent (e.g. `homeassistant-stubs`)
- Updated PR title/branch/body to use "refresh" instead of "update"
- Removed the stale reference to dependabot-core#14073 (that issue is about version updates for transitive deps, which the `uv` ecosystem now handles for security updates)

## ❓ Why

The previous `pip` ecosystem config was wrong for this project — it uses `uv.lock`, not `requirements.txt`. The workflow comment implied it was filling a gap that Dependabot couldn't fill, when in reality both tools share the same fundamental limitation: neither can upgrade a transitive dependency beyond what its parent allows.