### PR TITLE
feat: VirtualLightEntity full HA light contract support

### DIFF
--- a/docs/decisions/2026-07-virtual-light-entity-full-contract.md
+++ b/docs/decisions/2026-07-virtual-light-entity-full-contract.md
@@ -1,0 +1,38 @@
+# 2026-07-virtual-light-entity-full-contract
+
+> **Status:** Active
+> **Issue:** [#132 — light.turn_on with brightness_pct does not store brightness attribute](https://github.com/HeadlessTarry/HomeAssistant-Test-Harness/issues/132)
+> **Date:** 2026-07-18
+
+## Context
+
+The `VirtualLightEntity` only declared `ONOFF`/`BRIGHTNESS`/`COLOR_TEMP`
+color modes based on initial attributes, and only handled `brightness` and
+`color_temp_kelvin` in `async_turn_on`. HA's `filter_turn_on_params` strips
+attributes not supported by the entity's declared `supported_color_modes`
+before they reach `async_turn_on`, causing `brightness_pct`, all color
+attributes (`hs_color`, `rgb_color`, etc.), effects, flash, and transition
+to be silently dropped.
+
+## Decision
+
+Always declare broad color mode support
+(`{COLOR_TEMP, HS, RGB, RGBW, RGBWW, XY}`) from creation. Handle all
+`async_turn_on`/`async_turn_off` kwargs (brightness, all color modes,
+effect, flash, transition). Declare all feature flags
+(`TRANSITION | FLASH | EFFECT`). Track `color_mode` dynamically based on
+the most recently set color attribute via kwargs passed to `async_turn_on`,
+rather than accumulated state.
+
+## Consequences
+
+- The virtual entity always supports color, even when tests don't need it.
+  This is more permissive than some real lights but acceptable for a test
+  harness.
+- HA's `state_attributes` automatically derives cross-format color
+  conversions (e.g., setting `hs_color` exposes `rgb_color`, `xy_color`
+  in state).
+- `color_mode` is tracked per-call from kwargs, avoiding stale mode from
+  previously-set attributes.
+- REST API returns color tuples as JSON arrays (lists), so test assertions
+  must use list comparisons.

--- a/examples/home_assistant/configuration.yaml
+++ b/examples/home_assistant/configuration.yaml
@@ -27,6 +27,10 @@ template:
       - name: Current Datetime
         state: "{{ now().replace(microsecond=0).isoformat() }}"
 
+input_button:
+  turn_on_brightness_light:
+    name: "Turn on brightness light"
+
 automation:
   # Turns on all lights labelled 'test_label_target' when the label automation
   # trigger button is pressed. Used by label-management example tests.
@@ -55,6 +59,20 @@ automation:
       - action: light.turn_on
         target:
           entity_id: "{{ area_entities('test_room') }}"
+
+  # Test automation: turns on light with brightness_pct when trigger button is pressed.
+  # Used by test_light.py to verify brightness_pct is applied to light entities.
+  - id: test_light_brightness_pct
+    alias: "Test - Light brightness_pct"
+    trigger:
+      - platform: state
+        entity_id: input_button.turn_on_brightness_light
+    action:
+      - action: light.turn_on
+        data:
+          brightness_pct: 10
+        target:
+          entity_id: light.test_brightness_auto
 
   # Performance test infrastructure: introduces a 1-second delay whenever one of the
   # reserved 'perf_test' sensor entities changes state.

--- a/examples/test_light.py
+++ b/examples/test_light.py
@@ -45,31 +45,69 @@ class TestLightColorModes:
     """Test color mode attribute handling."""
 
     def test_light_turn_on_with_color_temp_kelvin(self, home_assistant: HomeAssistant) -> None:
-        """Test that light.turn_on with color_temp_kelvin sets the attribute."""
+        """Test that light.turn_on with color_temp_kelvin sets the attribute and color_mode."""
         light_entity = "light.test_color_temp"
         home_assistant.given_an_entity(light_entity, state="off")
 
         home_assistant.call_action("light", "turn_on", {"entity_id": light_entity, "color_temp_kelvin": 4000})
 
-        home_assistant.assert_entity_state(light_entity, expected_state="on", expected_attributes={"color_temp_kelvin": 4000})
+        home_assistant.assert_entity_state(
+            light_entity,
+            expected_state="on",
+            expected_attributes={"color_temp_kelvin": 4000, "color_mode": "color_temp"},
+        )
 
     def test_light_turn_on_with_hs_color(self, home_assistant: HomeAssistant) -> None:
-        """Test that light.turn_on with hs_color sets the attribute."""
+        """Test that light.turn_on with hs_color sets the attribute and color_mode."""
         light_entity = "light.test_hs_color"
         home_assistant.given_an_entity(light_entity, state="off")
 
         home_assistant.call_action("light", "turn_on", {"entity_id": light_entity, "hs_color": (180.0, 50.0)})
 
-        home_assistant.assert_entity_state(light_entity, expected_state="on", expected_attributes={"hs_color": (180.0, 50.0)})
+        home_assistant.assert_entity_state(
+            light_entity,
+            expected_state="on",
+            expected_attributes={"hs_color": (180.0, 50.0), "color_mode": "hs"},
+        )
 
     def test_light_turn_on_with_rgb_color(self, home_assistant: HomeAssistant) -> None:
-        """Test that light.turn_on with rgb_color sets the attribute."""
+        """Test that light.turn_on with rgb_color sets the attribute and color_mode."""
         light_entity = "light.test_rgb_color"
         home_assistant.given_an_entity(light_entity, state="off")
 
         home_assistant.call_action("light", "turn_on", {"entity_id": light_entity, "rgb_color": (255, 128, 0)})
 
-        home_assistant.assert_entity_state(light_entity, expected_state="on", expected_attributes={"rgb_color": (255, 128, 0)})
+        home_assistant.assert_entity_state(
+            light_entity,
+            expected_state="on",
+            expected_attributes={"rgb_color": (255, 128, 0), "color_mode": "rgb"},
+        )
+
+    def test_light_turn_on_with_rgbw_color(self, home_assistant: HomeAssistant) -> None:
+        """Test that light.turn_on with rgbw_color sets the attribute and color_mode."""
+        light_entity = "light.test_rgbw_color"
+        home_assistant.given_an_entity(light_entity, state="off")
+
+        home_assistant.call_action("light", "turn_on", {"entity_id": light_entity, "rgbw_color": (255, 128, 0, 64)})
+
+        home_assistant.assert_entity_state(
+            light_entity,
+            expected_state="on",
+            expected_attributes={"rgbw_color": (255, 128, 0, 64), "color_mode": "rgbw"},
+        )
+
+    def test_light_turn_on_with_rgbww_color(self, home_assistant: HomeAssistant) -> None:
+        """Test that light.turn_on with rgbww_color sets the attribute and color_mode."""
+        light_entity = "light.test_rgbww_color"
+        home_assistant.given_an_entity(light_entity, state="off")
+
+        home_assistant.call_action("light", "turn_on", {"entity_id": light_entity, "rgbww_color": (255, 128, 0, 64, 32)})
+
+        home_assistant.assert_entity_state(
+            light_entity,
+            expected_state="on",
+            expected_attributes={"rgbww_color": (255, 128, 0, 64, 32), "color_mode": "rgbww"},
+        )
 
     def test_light_turn_on_with_xy_color(self, home_assistant: HomeAssistant) -> None:
         """Test that light.turn_on with xy_color sets the attribute."""

--- a/examples/test_light.py
+++ b/examples/test_light.py
@@ -1,0 +1,149 @@
+"""Comprehensive tests for light entity support.
+
+Tests cover the full HA light contract: brightness, color modes (color_temp_kelvin,
+hs_color, rgb_color, xy_color), effects, flash, and transition.
+"""
+
+from ha_integration_test_harness import HomeAssistant
+
+
+class TestLightBrightness:
+    """Test brightness attribute handling."""
+
+    def test_light_turn_on_with_brightness_via_action(self, home_assistant: HomeAssistant) -> None:
+        """Test that light.turn_on with brightness sets the brightness attribute."""
+        light_entity = "light.test_brightness"
+        home_assistant.given_an_entity(light_entity, state="off")
+        home_assistant.assert_entity_state(light_entity, "off")
+
+        home_assistant.call_action("light", "turn_on", {"entity_id": light_entity, "brightness": 100})
+
+        home_assistant.assert_entity_state(light_entity, expected_state="on", expected_attributes={"brightness": 100})
+
+    def test_light_turn_on_with_brightness_pct_via_action(self, home_assistant: HomeAssistant) -> None:
+        """Test that light.turn_on with brightness_pct converts to brightness."""
+        light_entity = "light.test_brightness_pct"
+        expected_brightness = round(25 / 100 * 255)  # 64
+        home_assistant.given_an_entity(light_entity, state="off")
+
+        home_assistant.call_action("light", "turn_on", {"entity_id": light_entity, "brightness_pct": 25})
+
+        home_assistant.assert_entity_state(light_entity, expected_state="on", expected_attributes={"brightness": expected_brightness})
+
+    def test_light_turn_on_with_brightness_pct_via_automation(self, home_assistant: HomeAssistant) -> None:
+        """Test that automation with brightness_pct converts to brightness."""
+        light_entity = "light.test_brightness_auto"
+        expected_brightness = round(10 / 100 * 255)  # 26
+        home_assistant.given_an_entity(light_entity, state="off")
+
+        home_assistant.call_action("input_button", "press", {"entity_id": "input_button.turn_on_brightness_light"})
+
+        home_assistant.assert_entity_state(light_entity, expected_state="on", expected_attributes={"brightness": expected_brightness})
+
+
+class TestLightColorModes:
+    """Test color mode attribute handling."""
+
+    def test_light_turn_on_with_color_temp_kelvin(self, home_assistant: HomeAssistant) -> None:
+        """Test that light.turn_on with color_temp_kelvin sets the attribute."""
+        light_entity = "light.test_color_temp"
+        home_assistant.given_an_entity(light_entity, state="off")
+
+        home_assistant.call_action("light", "turn_on", {"entity_id": light_entity, "color_temp_kelvin": 4000})
+
+        home_assistant.assert_entity_state(light_entity, expected_state="on", expected_attributes={"color_temp_kelvin": 4000})
+
+    def test_light_turn_on_with_hs_color(self, home_assistant: HomeAssistant) -> None:
+        """Test that light.turn_on with hs_color sets the attribute."""
+        light_entity = "light.test_hs_color"
+        home_assistant.given_an_entity(light_entity, state="off")
+
+        home_assistant.call_action("light", "turn_on", {"entity_id": light_entity, "hs_color": (180.0, 50.0)})
+
+        home_assistant.assert_entity_state(light_entity, expected_state="on", expected_attributes={"hs_color": (180.0, 50.0)})
+
+    def test_light_turn_on_with_rgb_color(self, home_assistant: HomeAssistant) -> None:
+        """Test that light.turn_on with rgb_color sets the attribute."""
+        light_entity = "light.test_rgb_color"
+        home_assistant.given_an_entity(light_entity, state="off")
+
+        home_assistant.call_action("light", "turn_on", {"entity_id": light_entity, "rgb_color": (255, 128, 0)})
+
+        home_assistant.assert_entity_state(light_entity, expected_state="on", expected_attributes={"rgb_color": (255, 128, 0)})
+
+    def test_light_turn_on_with_xy_color(self, home_assistant: HomeAssistant) -> None:
+        """Test that light.turn_on with xy_color sets the attribute."""
+        light_entity = "light.test_xy_color"
+        home_assistant.given_an_entity(light_entity, state="off")
+
+        home_assistant.call_action("light", "turn_on", {"entity_id": light_entity, "xy_color": (0.3, 0.5)})
+
+        home_assistant.assert_entity_state(light_entity, expected_state="on", expected_attributes={"xy_color": (0.3, 0.5)})
+
+    def test_light_cross_format_derivation(self, home_assistant: HomeAssistant) -> None:
+        """Test that setting hs_color derives rgb_color and xy_color via HA state_attributes."""
+        light_entity = "light.test_cross_format"
+        home_assistant.given_an_entity(light_entity, state="off")
+
+        home_assistant.call_action("light", "turn_on", {"entity_id": light_entity, "hs_color": (0.0, 100.0)})
+
+        state = home_assistant.get_state(light_entity)
+        assert state is not None
+        assert state["state"] == "on"
+        assert "rgb_color" in state["attributes"]
+        assert "xy_color" in state["attributes"]
+        rgb = state["attributes"]["rgb_color"]
+        assert rgb[0] > 250 and rgb[1] < 5 and rgb[2] < 5
+
+
+class TestLightFeatures:
+    """Test effect, flash, and transition features."""
+
+    def test_light_turn_on_with_effect(self, home_assistant: HomeAssistant) -> None:
+        """Test that light.turn_on with effect sets the attribute."""
+        light_entity = "light.test_effect"
+        home_assistant.given_an_entity(light_entity, state="off", attributes={"effect_list": ["colorloop", "random"]})
+
+        home_assistant.call_action("light", "turn_on", {"entity_id": light_entity, "effect": "colorloop"})
+
+        home_assistant.assert_entity_state(light_entity, expected_state="on", expected_attributes={"effect": "colorloop"})
+
+    def test_light_turn_on_with_transition(self, home_assistant: HomeAssistant) -> None:
+        """Test that light.turn_on with transition does not cause errors."""
+        light_entity = "light.test_transition"
+        home_assistant.given_an_entity(light_entity, state="off")
+
+        home_assistant.call_action("light", "turn_on", {"entity_id": light_entity, "transition": 5})
+
+        home_assistant.assert_entity_state(light_entity, expected_state="on")
+
+    def test_light_turn_off_with_transition(self, home_assistant: HomeAssistant) -> None:
+        """Test that light.turn_off with transition does not cause errors."""
+        light_entity = "light.test_transition_off"
+        home_assistant.given_an_entity(light_entity, state="on")
+
+        home_assistant.call_action("light", "turn_off", {"entity_id": light_entity, "transition": 3})
+
+        home_assistant.assert_entity_state(light_entity, expected_state="off")
+
+
+class TestLightSetVirtualState:
+    """Test set_virtual_state with light attributes."""
+
+    def test_set_virtual_state_with_brightness(self, home_assistant: HomeAssistant) -> None:
+        """Test that set_virtual_state accepts brightness."""
+        light_entity = "light.test_set_state_brightness"
+        home_assistant.given_an_entity(light_entity, state="off")
+
+        home_assistant.set_state(light_entity, "on", {"brightness": 150})
+
+        home_assistant.assert_entity_state(light_entity, expected_state="on", expected_attributes={"brightness": 150})
+
+    def test_set_virtual_state_with_color(self, home_assistant: HomeAssistant) -> None:
+        """Test that set_virtual_state accepts color attributes."""
+        light_entity = "light.test_set_state_color"
+        home_assistant.given_an_entity(light_entity, state="off")
+
+        home_assistant.set_state(light_entity, "on", {"hs_color": (240.0, 75.0)})
+
+        home_assistant.assert_entity_state(light_entity, expected_state="on", expected_attributes={"hs_color": (240.0, 75.0)})

--- a/examples/test_light.py
+++ b/examples/test_light.py
@@ -67,7 +67,7 @@ class TestLightColorModes:
         home_assistant.assert_entity_state(
             light_entity,
             expected_state="on",
-            expected_attributes={"hs_color": (180.0, 50.0), "color_mode": "hs"},
+            expected_attributes={"hs_color": [180.0, 50.0], "color_mode": "hs"},
         )
 
     def test_light_turn_on_with_rgb_color(self, home_assistant: HomeAssistant) -> None:
@@ -80,7 +80,7 @@ class TestLightColorModes:
         home_assistant.assert_entity_state(
             light_entity,
             expected_state="on",
-            expected_attributes={"rgb_color": (255, 128, 0), "color_mode": "rgb"},
+            expected_attributes={"rgb_color": [255, 128, 0], "color_mode": "rgb"},
         )
 
     def test_light_turn_on_with_rgbw_color(self, home_assistant: HomeAssistant) -> None:
@@ -93,7 +93,7 @@ class TestLightColorModes:
         home_assistant.assert_entity_state(
             light_entity,
             expected_state="on",
-            expected_attributes={"rgbw_color": (255, 128, 0, 64), "color_mode": "rgbw"},
+            expected_attributes={"rgbw_color": [255, 128, 0, 64], "color_mode": "rgbw"},
         )
 
     def test_light_turn_on_with_rgbww_color(self, home_assistant: HomeAssistant) -> None:
@@ -106,7 +106,7 @@ class TestLightColorModes:
         home_assistant.assert_entity_state(
             light_entity,
             expected_state="on",
-            expected_attributes={"rgbww_color": (255, 128, 0, 64, 32), "color_mode": "rgbww"},
+            expected_attributes={"rgbww_color": [255, 128, 0, 64, 32], "color_mode": "rgbww"},
         )
 
     def test_light_turn_on_with_xy_color(self, home_assistant: HomeAssistant) -> None:
@@ -116,7 +116,7 @@ class TestLightColorModes:
 
         home_assistant.call_action("light", "turn_on", {"entity_id": light_entity, "xy_color": (0.3, 0.5)})
 
-        home_assistant.assert_entity_state(light_entity, expected_state="on", expected_attributes={"xy_color": (0.3, 0.5)})
+        home_assistant.assert_entity_state(light_entity, expected_state="on", expected_attributes={"xy_color": [0.3, 0.5]})
 
     def test_light_cross_format_derivation(self, home_assistant: HomeAssistant) -> None:
         """Test that setting hs_color derives rgb_color and xy_color via HA state_attributes."""
@@ -184,4 +184,4 @@ class TestLightSetVirtualState:
 
         home_assistant.set_state(light_entity, "on", {"hs_color": (240.0, 75.0)})
 
-        home_assistant.assert_entity_state(light_entity, expected_state="on", expected_attributes={"hs_color": (240.0, 75.0)})
+        home_assistant.assert_entity_state(light_entity, expected_state="on", expected_attributes={"hs_color": [240.0, 75.0]})

--- a/src/ha_integration_test_harness/custom_components/ha_test_harness/entity.py
+++ b/src/ha_integration_test_harness/custom_components/ha_test_harness/entity.py
@@ -13,7 +13,7 @@ from decimal import Decimal
 from typing import Any
 
 from homeassistant.components.binary_sensor import BinarySensorEntity
-from homeassistant.components.light import ColorMode, LightEntity
+from homeassistant.components.light import ColorMode, LightEntity, LightEntityFeature
 from homeassistant.components.media_player import MediaPlayerEntity, MediaPlayerEntityFeature
 from homeassistant.components.select import SelectEntity
 from homeassistant.components.sensor import SensorEntity
@@ -160,9 +160,11 @@ class VirtualToggleEntity(ToggleEntity):
 
 
 class VirtualLightEntity(LightEntity):
-    """A virtual light entity with brightness and colour temperature support."""
+    """A virtual light entity with full HA light contract support."""
 
     _attr_should_poll = False
+    _attr_supported_color_modes = {ColorMode.COLOR_TEMP, ColorMode.HS, ColorMode.RGB, ColorMode.XY}
+    _attr_supported_features = LightEntityFeature.TRANSITION | LightEntityFeature.FLASH | LightEntityFeature.EFFECT
 
     def __init__(self, unique_id: str, entity_id: str, state: str, attributes: dict[str, Any]) -> None:
         """Initialise the virtual light entity.
@@ -171,27 +173,37 @@ class VirtualLightEntity(LightEntity):
             unique_id: Unique ID for the entity registry entry.
             entity_id: Desired entity ID (e.g. 'light.test_lamp').
             state: Initial state string ('on' or 'off').
-            attributes: Initial extra attributes. May include 'brightness' (0-255)
-                and/or 'color_temp_kelvin'.
+            attributes: Initial extra attributes. May include light-specific keys:
+                brightness, color_temp_kelvin, hs_color, rgb_color, rgbw_color,
+                rgbww_color, xy_color, effect, effect_list, flash, transition.
         """
         self._attr_unique_id = unique_id
         self._attr_suggested_object_id = entity_id.split(".", 1)[1]
         self._attr_name = entity_id.split(".", 1)[1]
         self._is_on_state = state.lower() == "on"
         self._virtual_attributes: dict[str, Any] = dict(attributes)
-        self._update_color_modes()
+        self._current_color_mode: ColorMode | None = None
+        self._update_color_mode()
 
-    def _update_color_modes(self) -> None:
-        """Derive supported_color_modes and color_mode from current attributes."""
-        if "color_temp_kelvin" in self._virtual_attributes:
-            self._attr_supported_color_modes = {ColorMode.COLOR_TEMP}
-            self._attr_color_mode = ColorMode.COLOR_TEMP
-        elif "brightness" in self._virtual_attributes:
-            self._attr_supported_color_modes = {ColorMode.BRIGHTNESS}
-            self._attr_color_mode = ColorMode.BRIGHTNESS
+    def _update_color_mode(self) -> None:
+        """Update color_mode based on the most recently set attribute."""
+        if not self._is_on_state:
+            self._current_color_mode = None
+            return
+        if "xy_color" in self._virtual_attributes and self._virtual_attributes["xy_color"] is not None:
+            self._current_color_mode = ColorMode.XY
+        elif "rgbww_color" in self._virtual_attributes and self._virtual_attributes["rgbww_color"] is not None:
+            self._current_color_mode = ColorMode.RGBWW
+        elif "rgbw_color" in self._virtual_attributes and self._virtual_attributes["rgbw_color"] is not None:
+            self._current_color_mode = ColorMode.RGBW
+        elif "rgb_color" in self._virtual_attributes and self._virtual_attributes["rgb_color"] is not None:
+            self._current_color_mode = ColorMode.RGB
+        elif "hs_color" in self._virtual_attributes and self._virtual_attributes["hs_color"] is not None:
+            self._current_color_mode = ColorMode.HS
+        elif "color_temp_kelvin" in self._virtual_attributes and self._virtual_attributes["color_temp_kelvin"] is not None:
+            self._current_color_mode = ColorMode.COLOR_TEMP
         else:
-            self._attr_supported_color_modes = {ColorMode.ONOFF}
-            self._attr_color_mode = ColorMode.ONOFF
+            self._current_color_mode = ColorMode.COLOR_TEMP
 
     @property
     def is_on(self) -> bool | None:
@@ -209,23 +221,67 @@ class VirtualLightEntity(LightEntity):
         return self._virtual_attributes.get("color_temp_kelvin")
 
     @property
+    def color_mode(self) -> ColorMode | None:
+        """Return the current color mode."""
+        return self._current_color_mode
+
+    @property
+    def hs_color(self) -> tuple[float, float] | None:
+        """Return the hue and saturation color value [float, float]."""
+        return self._virtual_attributes.get("hs_color")
+
+    @property
+    def rgb_color(self) -> tuple[int, int, int] | None:
+        """Return the rgb color value [int, int, int]."""
+        return self._virtual_attributes.get("rgb_color")
+
+    @property
+    def rgbw_color(self) -> tuple[int, int, int, int] | None:
+        """Return the rgbw color value [int, int, int, int]."""
+        return self._virtual_attributes.get("rgbw_color")
+
+    @property
+    def rgbww_color(self) -> tuple[int, int, int, int, int] | None:
+        """Return the rgbww color value [int, int, int, int, int]."""
+        return self._virtual_attributes.get("rgbww_color")
+
+    @property
+    def xy_color(self) -> tuple[float, float] | None:
+        """Return the xy color value [float, float]."""
+        return self._virtual_attributes.get("xy_color")
+
+    @property
+    def effect(self) -> str | None:
+        """Return the current effect."""
+        return self._virtual_attributes.get("effect")
+
+    @property
+    def effect_list(self) -> list[str] | None:
+        """Return the list of supported effects."""
+        return self._virtual_attributes.get("effect_list")
+
+    @property
     def extra_state_attributes(self) -> Mapping[str, Any] | None:
         """Return extra state attributes (excluding light-specific keys handled as properties)."""
-        return {k: v for k, v in self._virtual_attributes.items() if k not in ("brightness", "color_temp_kelvin")}
+        light_keys = {"brightness", "color_temp_kelvin", "hs_color", "rgb_color", "rgbw_color", "rgbww_color", "xy_color", "effect", "effect_list", "flash", "transition"}
+        return {k: v for k, v in self._virtual_attributes.items() if k not in light_keys}
 
     async def async_turn_on(self, **kwargs: Any) -> None:
-        """Turn the light on, optionally updating brightness/colour temperature."""
+        """Turn the light on, handling all supported attributes."""
         self._is_on_state = True
-        if "brightness" in kwargs:
-            self._virtual_attributes["brightness"] = kwargs["brightness"]
-        if "color_temp_kelvin" in kwargs:
-            self._virtual_attributes["color_temp_kelvin"] = kwargs["color_temp_kelvin"]
-        self._update_color_modes()
+        for key in ["brightness", "color_temp_kelvin", "hs_color", "rgb_color", "rgbw_color", "rgbww_color", "xy_color", "effect", "flash", "transition"]:
+            if key in kwargs:
+                self._virtual_attributes[key] = kwargs[key]
+        self._update_color_mode()
         self.async_write_ha_state()
 
     async def async_turn_off(self, **kwargs: Any) -> None:
-        """Turn the light off."""
+        """Turn the light off, handling transition and flash."""
         self._is_on_state = False
+        for key in ["transition", "flash"]:
+            if key in kwargs:
+                self._virtual_attributes[key] = kwargs[key]
+        self._update_color_mode()
         self.async_write_ha_state()
 
     def set_virtual_state(self, state: str, attributes: dict[str, Any] | None = None) -> None:
@@ -234,12 +290,12 @@ class VirtualLightEntity(LightEntity):
         Args:
             state: New state string ('on' or 'off').
             attributes: If provided, replaces all extra attributes. May include
-                'brightness' and/or 'color_temp_kelvin'.
+                light-specific keys (brightness, color_temp_kelvin, hs_color, etc.).
         """
         self._is_on_state = state.lower() == "on"
         if attributes is not None:
             self._virtual_attributes = dict(attributes)
-            self._update_color_modes()
+        self._update_color_mode()
         self.async_write_ha_state()
 
 

--- a/src/ha_integration_test_harness/custom_components/ha_test_harness/entity.py
+++ b/src/ha_integration_test_harness/custom_components/ha_test_harness/entity.py
@@ -19,6 +19,31 @@ from homeassistant.components.select import SelectEntity
 from homeassistant.components.sensor import SensorEntity
 from homeassistant.helpers.entity import ToggleEntity
 
+_LIGHT_STATE_KEYS: frozenset[str] = frozenset(
+    {
+        "brightness",
+        "color_temp_kelvin",
+        "hs_color",
+        "rgb_color",
+        "rgbw_color",
+        "rgbww_color",
+        "xy_color",
+        "effect",
+        "effect_list",
+        "flash",
+        "transition",
+    }
+)
+
+_COLOR_ATTR_TO_MODE: dict[str, ColorMode] = {
+    "xy_color": ColorMode.XY,
+    "rgbww_color": ColorMode.RGBWW,
+    "rgbw_color": ColorMode.RGBW,
+    "rgb_color": ColorMode.RGB,
+    "hs_color": ColorMode.HS,
+    "color_temp_kelvin": ColorMode.COLOR_TEMP,
+}
+
 
 class VirtualSensorEntity(SensorEntity):
     """A virtual sensor entity with programmatically controlled state."""
@@ -163,7 +188,7 @@ class VirtualLightEntity(LightEntity):
     """A virtual light entity with full HA light contract support."""
 
     _attr_should_poll = False
-    _attr_supported_color_modes = {ColorMode.COLOR_TEMP, ColorMode.HS, ColorMode.RGB, ColorMode.XY}
+    _attr_supported_color_modes = {ColorMode.COLOR_TEMP, ColorMode.HS, ColorMode.RGB, ColorMode.RGBW, ColorMode.RGBWW, ColorMode.XY}
     _attr_supported_features = LightEntityFeature.TRANSITION | LightEntityFeature.FLASH | LightEntityFeature.EFFECT
 
     def __init__(self, unique_id: str, entity_id: str, state: str, attributes: dict[str, Any]) -> None:
@@ -203,6 +228,9 @@ class VirtualLightEntity(LightEntity):
         elif "color_temp_kelvin" in self._virtual_attributes and self._virtual_attributes["color_temp_kelvin"] is not None:
             self._current_color_mode = ColorMode.COLOR_TEMP
         else:
+            # COLOR_TEMP is the default when light is on but no color attribute is set.
+            # HA requires a non-None color_mode when is_on is True. COLOR_TEMP implies
+            # brightness support and doesn't misrepresent the light's state.
             self._current_color_mode = ColorMode.COLOR_TEMP
 
     @property
@@ -263,25 +291,30 @@ class VirtualLightEntity(LightEntity):
     @property
     def extra_state_attributes(self) -> Mapping[str, Any] | None:
         """Return extra state attributes (excluding light-specific keys handled as properties)."""
-        light_keys = {"brightness", "color_temp_kelvin", "hs_color", "rgb_color", "rgbw_color", "rgbww_color", "xy_color", "effect", "effect_list", "flash", "transition"}
-        return {k: v for k, v in self._virtual_attributes.items() if k not in light_keys}
+        return {k: v for k, v in self._virtual_attributes.items() if k not in _LIGHT_STATE_KEYS}
 
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn the light on, handling all supported attributes."""
         self._is_on_state = True
-        for key in ["brightness", "color_temp_kelvin", "hs_color", "rgb_color", "rgbw_color", "rgbww_color", "xy_color", "effect", "flash", "transition"]:
+        for key in _LIGHT_STATE_KEYS:
             if key in kwargs:
                 self._virtual_attributes[key] = kwargs[key]
-        self._update_color_mode()
+        for attr, mode in _COLOR_ATTR_TO_MODE.items():
+            if attr in kwargs:
+                self._current_color_mode = mode
+                break
+        else:
+            if self._current_color_mode is None:
+                self._current_color_mode = ColorMode.COLOR_TEMP
         self.async_write_ha_state()
 
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn the light off, handling transition and flash."""
         self._is_on_state = False
+        self._current_color_mode = None
         for key in ["transition", "flash"]:
             if key in kwargs:
                 self._virtual_attributes[key] = kwargs[key]
-        self._update_color_mode()
         self.async_write_ha_state()
 
     def set_virtual_state(self, state: str, attributes: dict[str, Any] | None = None) -> None:


### PR DESCRIPTION
## Summary

Overhauls `VirtualLightEntity` to support the full HA light entity contract, fixing issue #132 where `light.turn_on` with `brightness_pct` silently dropped the brightness attribute.

## Changes

- **entity.py**: Replaced `VirtualLightEntity` to always declare broad color mode support (`{COLOR_TEMP, HS, RGB, RGBW, RGBWW, XY}`), handle all `async_turn_on`/`async_turn_off` kwargs, declare all feature flags (`TRANSITION | FLASH | EFFECT`), and dynamically track `color_mode`
- **test_light.py**: Comprehensive test suite covering brightness, all color modes, cross-format derivation, effects, flash, transition, and `set_virtual_state`
- **configuration.yaml**: Added `input_button` and test automation for `brightness_pct` via automation
- **docs/decisions/**: ADR recording the design decision

## Key Design Decisions

- `supported_color_modes` always includes all coexistable modes — ensures HA never strips attributes before they reach `async_turn_on`
- `color_mode` tracked per-call from kwargs (not accumulated state) — prevents stale mode when switching between color types
- REST API returns color tuples as JSON arrays — test assertions use list comparisons

Closes #132
