### PR TITLE
feat: add request timeouts and hang diagnostics

### DIFF
--- a/src/ha_integration_test_harness/__init__.py
+++ b/src/ha_integration_test_harness/__init__.py
@@ -30,6 +30,7 @@ from .exceptions import (
     AppDaemonClientError,
     DockerError,
     HomeAssistantClientError,
+    HomeAssistantTimeoutError,
     IntegrationTestError,
     TimeMachineError,
 )
@@ -52,6 +53,7 @@ __all__ = [
     "DockerError",
     "HomeAssistant",
     "HomeAssistantClientError",
+    "HomeAssistantTimeoutError",
     "IntegrationTestError",
     "TimeMachine",
     "TimeMachineError",

--- a/src/ha_integration_test_harness/conftest.py
+++ b/src/ha_integration_test_harness/conftest.py
@@ -8,6 +8,7 @@ import pytest
 
 from .appdaemon_client import AppDaemon
 from .docker_manager import DockerComposeManager
+from .exceptions import HomeAssistantTimeoutError
 from .homeassistant_client import HomeAssistant
 from .time_machine import TimeMachine
 
@@ -16,11 +17,26 @@ logger = logging.getLogger(__name__)
 # Session-level flag to capture diagnostics only once
 _diagnostics_captured = False
 _failure_key: pytest.StashKey[bool] = pytest.StashKey()
+_docker_manager_key: pytest.StashKey[Optional[DockerComposeManager]] = pytest.StashKey()
 
 
 def pytest_runtest_makereport(item: pytest.Item, call: pytest.CallInfo[Any]) -> None:
-    """Pytest hook to detect test failures and mark for diagnostics capture."""
+    """Pytest hook to detect test failures and mark for diagnostics capture.
+    
+    When a HomeAssistantTimeoutError is detected, immediately capture and log
+    container diagnostics to help diagnose the cause of the timeout.
+    """
+    global _diagnostics_captured
+    
     if call.when == "call" and call.excinfo is not None:
+        # Check if this is a timeout exception
+        if isinstance(call.excinfo.value, HomeAssistantTimeoutError):
+            # Try to get the docker manager from session stash
+            docker_manager = item.session.stash.get(_docker_manager_key, None)
+            if docker_manager is not None and not _diagnostics_captured:
+                logger.warning(f"Home Assistant request timed out\n{docker_manager.get_container_diagnostics()}")
+                _diagnostics_captured = True
+        
         # Test failed - mark in session stash
         if not item.session.stash.get(_failure_key, False):
             item.session.stash[_failure_key] = True
@@ -80,6 +96,8 @@ def docker(request: pytest.FixtureRequest) -> Generator[DockerComposeManager, No
     manager: Optional[DockerComposeManager] = None
     try:
         manager = DockerComposeManager(persistent_entities_path=persistent_entities_path)
+        # Store the manager in session stash so it can be accessed by hooks
+        request.session.stash[_docker_manager_key] = manager
         manager.start()
         logger.info("Docker containers started successfully")
         yield manager

--- a/src/ha_integration_test_harness/conftest.py
+++ b/src/ha_integration_test_harness/conftest.py
@@ -34,7 +34,13 @@ def pytest_runtest_makereport(item: pytest.Item, call: pytest.CallInfo[Any]) -> 
             # Try to get the docker manager from session stash
             docker_manager = item.session.stash.get(_docker_manager_key, None)
             if docker_manager is not None and not _diagnostics_captured:
-                logger.warning(f"Home Assistant request timed out\n{docker_manager.get_container_diagnostics()}")
+                # Capture test context for diagnostics
+                test_name = item.nodeid
+                test_duration = call.duration if hasattr(call, "duration") else None
+                logger.warning(
+                    f"Home Assistant request timed out\n"
+                    f"{docker_manager.get_container_diagnostics(test_name=test_name, test_duration=test_duration)}"
+                )
                 _diagnostics_captured = True
         
         # Test failed - mark in session stash

--- a/src/ha_integration_test_harness/conftest.py
+++ b/src/ha_integration_test_harness/conftest.py
@@ -22,12 +22,12 @@ _docker_manager_key: pytest.StashKey[Optional[DockerComposeManager]] = pytest.St
 
 def pytest_runtest_makereport(item: pytest.Item, call: pytest.CallInfo[Any]) -> None:
     """Pytest hook to detect test failures and mark for diagnostics capture.
-    
+
     When a HomeAssistantTimeoutError is detected, immediately capture and log
     container diagnostics to help diagnose the cause of the timeout.
     """
     global _diagnostics_captured
-    
+
     if call.when == "call" and call.excinfo is not None:
         # Check if this is a timeout exception
         if isinstance(call.excinfo.value, HomeAssistantTimeoutError):
@@ -37,12 +37,9 @@ def pytest_runtest_makereport(item: pytest.Item, call: pytest.CallInfo[Any]) -> 
                 # Capture test context for diagnostics
                 test_name = item.nodeid
                 test_duration = call.duration if hasattr(call, "duration") else None
-                logger.warning(
-                    f"Home Assistant request timed out\n"
-                    f"{docker_manager.get_container_diagnostics(test_name=test_name, test_duration=test_duration)}"
-                )
+                logger.warning(f"Home Assistant request timed out\n" f"{docker_manager.get_container_diagnostics(test_name=test_name, test_duration=test_duration)}")
                 _diagnostics_captured = True
-        
+
         # Test failed - mark in session stash
         if not item.session.stash.get(_failure_key, False):
             item.session.stash[_failure_key] = True

--- a/src/ha_integration_test_harness/containers/docker-compose.yaml
+++ b/src/ha_integration_test_harness/containers/docker-compose.yaml
@@ -18,7 +18,7 @@ services:
     entrypoint: ["/bin/bash", "/entrypoint.sh"]
     healthcheck:
       start_period: 5s
-      test: ["CMD", "test", "-f", "/shared_data/.homeassistant_ready"]
+      test: ["CMD", "sh", "-c", "test -f /shared_data/.homeassistant_ready && curl -sf --max-time 2 http://localhost:8123/ > /dev/null"]
       timeout: 2s
       retries: 30
       interval: 3s

--- a/src/ha_integration_test_harness/docker_manager.py
+++ b/src/ha_integration_test_harness/docker_manager.py
@@ -681,6 +681,54 @@ class DockerComposeManager:
             except Exception as e:
                 logger.warning(f"Failed to clean up staged config directory: {e}")
 
+    def _collect_docker_stats(self, logs: list[str]) -> None:
+        """Collect CPU/memory usage via docker stats."""
+        try:
+            result = subprocess.run(
+                ["docker", "stats", "--no-stream", "--format", "table {{.Name}}\t{{.CPUPerc}}\t{{.MemUsage}}\t{{.MemPerc}}"],
+                cwd=self._containers_dir,
+                capture_output=True,
+                text=True,
+                check=True,
+            )
+            logs.append("\n========== DOCKER STATS ==========")
+            logs.append(result.stdout)
+        except Exception as e:
+            logs.append(f"\n** ERROR ** Failed to get docker stats: {e}")
+
+    def _collect_docker_inspect(self, logs: list[str]) -> None:
+        """Collect detailed container state via docker inspect."""
+        try:
+            for container in self._containers.values():
+                inspect_format = "{{.Name}}: " "State={{.State.Status}}, " "Restarts={{.RestartCount}}, " "ExitCode={{.State.ExitCode}}, " "OOMKilled={{.State.OOMKilled}}"
+                result = subprocess.run(
+                    ["docker", "inspect", "--format", inspect_format, container.container_id],
+                    capture_output=True,
+                    text=True,
+                    check=True,
+                )
+                logs.append(result.stdout.strip())
+        except Exception as e:
+            logs.append(f"** ERROR ** Failed to get docker inspect: {e}")
+
+    def _collect_network_reachability(self, logs: list[str]) -> None:
+        """Test network reachability to Home Assistant API."""
+        try:
+            ha_container = self._get_container("homeassistant")
+            if ha_container and ha_container.url:
+                logs.append("\n========== NETWORK REACHABILITY ==========")
+                try:
+                    response = requests.get(f"{ha_container.url}/api/", timeout=5)
+                    logs.append(f"Home Assistant API reachable: HTTP {response.status_code}")
+                except requests.Timeout:
+                    logs.append("Home Assistant API UNREACHABLE: Request timed out after 5s")
+                except requests.ConnectionError:
+                    logs.append("Home Assistant API UNREACHABLE: Connection refused")
+                except Exception as e:
+                    logs.append(f"Home Assistant API UNREACHABLE: {e}")
+        except Exception as e:
+            logs.append(f"** ERROR ** Failed to test network reachability: {e}")
+
     def get_container_diagnostics(self, test_name: Optional[str] = None, test_duration: Optional[float] = None) -> str:
         """Dump logs and diagnostic information from all containers.
 
@@ -710,50 +758,9 @@ class DockerComposeManager:
         except Exception as e:
             logs.append(f"** ERROR ** Failed to dump container diagnostics: {e}")
 
-        # Docker stats (CPU/memory usage)
-        try:
-            result = subprocess.run(
-                ["docker", "stats", "--no-stream", "--format", "table {{.Name}}\t{{.CPUPerc}}\t{{.MemUsage}}\t{{.MemPerc}}"],
-                cwd=self._containers_dir,
-                capture_output=True,
-                text=True,
-                check=True,
-            )
-            logs.append("\n========== DOCKER STATS ==========")
-            logs.append(result.stdout)
-        except Exception as e:
-            logs.append(f"\n** ERROR ** Failed to get docker stats: {e}")
-
-        # Docker inspect (detailed state, restart count)
-        try:
-            for container in self._containers.values():
-                inspect_format = "{{.Name}}: " "State={{.State.Status}}, " "Restarts={{.RestartCount}}, " "ExitCode={{.State.ExitCode}}, " "OOMKilled={{.State.OOMKilled}}"
-                result = subprocess.run(
-                    ["docker", "inspect", "--format", inspect_format, container.container_id],
-                    capture_output=True,
-                    text=True,
-                    check=True,
-                )
-                logs.append(result.stdout.strip())
-        except Exception as e:
-            logs.append(f"** ERROR ** Failed to get docker inspect: {e}")
-
-        # Network reachability test for Home Assistant API
-        try:
-            ha_container = self._get_container("homeassistant")
-            if ha_container and ha_container.url:
-                logs.append("\n========== NETWORK REACHABILITY ==========")
-                try:
-                    response = requests.get(f"{ha_container.url}/api/", timeout=5)
-                    logs.append(f"Home Assistant API reachable: HTTP {response.status_code}")
-                except requests.Timeout:
-                    logs.append("Home Assistant API UNREACHABLE: Request timed out after 5s")
-                except requests.ConnectionError:
-                    logs.append("Home Assistant API UNREACHABLE: Connection refused")
-                except Exception as e:
-                    logs.append(f"Home Assistant API UNREACHABLE: {e}")
-        except Exception as e:
-            logs.append(f"** ERROR ** Failed to test network reachability: {e}")
+        self._collect_docker_stats(logs)
+        self._collect_docker_inspect(logs)
+        self._collect_network_reachability(logs)
 
         logs.append("========== END DIAGNOSTICS ==========")
         return "\n".join(logs)

--- a/src/ha_integration_test_harness/docker_manager.py
+++ b/src/ha_integration_test_harness/docker_manager.py
@@ -727,13 +727,7 @@ class DockerComposeManager:
         # Docker inspect (detailed state, restart count)
         try:
             for container in self._containers.values():
-                inspect_format = (
-                    "{{.Name}}: "
-                    "State={{.State.Status}}, "
-                    "Restarts={{.RestartCount}}, "
-                    "ExitCode={{.State.ExitCode}}, "
-                    "OOMKilled={{.State.OOMKilled}}"
-                )
+                inspect_format = "{{.Name}}: " "State={{.State.Status}}, " "Restarts={{.RestartCount}}, " "ExitCode={{.State.ExitCode}}, " "OOMKilled={{.State.OOMKilled}}"
                 result = subprocess.run(
                     ["docker", "inspect", "--format", inspect_format, container.container_id],
                     capture_output=True,

--- a/src/ha_integration_test_harness/docker_manager.py
+++ b/src/ha_integration_test_harness/docker_manager.py
@@ -681,7 +681,7 @@ class DockerComposeManager:
             except Exception as e:
                 logger.warning(f"Failed to clean up staged config directory: {e}")
 
-    def get_container_diagnostics(self) -> str:
+    def get_container_diagnostics(self, test_name: Optional[str] = None, test_duration: Optional[float] = None) -> str:
         """Dump logs and diagnostic information from all containers.
 
         Captures:
@@ -689,11 +689,20 @@ class DockerComposeManager:
         - Docker stats (CPU/memory usage)
         - Docker inspect (detailed state, restart count)
         - Network reachability test for Home Assistant API
+        - Current test name and duration (if provided)
+
+        Args:
+            test_name: Optional name of the test that triggered the diagnostics capture.
+            test_duration: Optional duration of the test in seconds.
 
         Returns:
             A string containing container diagnostics for debugging.
         """
         logs = ["========== CONTAINER DIAGNOSTICS =========="]
+        if test_name is not None:
+            logs.append(f"Test: {test_name}")
+            if test_duration is not None:
+                logs.append(f"Duration: {test_duration:.2f}s")
         try:
             self._containers = self._refresh_container_details()
             for container in self._containers.values():
@@ -718,8 +727,15 @@ class DockerComposeManager:
         # Docker inspect (detailed state, restart count)
         try:
             for container in self._containers.values():
+                inspect_format = (
+                    "{{.Name}}: "
+                    "State={{.State.Status}}, "
+                    "Restarts={{.RestartCount}}, "
+                    "ExitCode={{.State.ExitCode}}, "
+                    "OOMKilled={{.State.OOMKilled}}"
+                )
                 result = subprocess.run(
-                    ["docker", "inspect", "--format", "{{.Name}}: State={{.State.Status}}, Restarts={{.RestartCount}}, ExitCode={{.State.ExitCode}}, OOMKilled={{.State.OOMKilled}}", container.container_id],
+                    ["docker", "inspect", "--format", inspect_format, container.container_id],
                     capture_output=True,
                     text=True,
                     check=True,

--- a/src/ha_integration_test_harness/docker_manager.py
+++ b/src/ha_integration_test_harness/docker_manager.py
@@ -699,8 +699,8 @@ class DockerComposeManager:
     def _collect_docker_inspect(self, logs: list[str]) -> None:
         """Collect detailed container state via docker inspect."""
         try:
+            inspect_format = "{{.Name}}: State={{.State.Status}}, Restarts={{.RestartCount}}, ExitCode={{.State.ExitCode}}, OOMKilled={{.State.OOMKilled}}"
             for container in self._containers.values():
-                inspect_format = "{{.Name}}: " "State={{.State.Status}}, " "Restarts={{.RestartCount}}, " "ExitCode={{.State.ExitCode}}, " "OOMKilled={{.State.OOMKilled}}"
                 result = subprocess.run(
                     ["docker", "inspect", "--format", inspect_format, container.container_id],
                     capture_output=True,

--- a/src/ha_integration_test_harness/docker_manager.py
+++ b/src/ha_integration_test_harness/docker_manager.py
@@ -12,6 +12,7 @@ import uuid
 from pathlib import Path
 from typing import Optional
 
+import requests
 import yaml
 
 from .exceptions import DockerError, PersistentEntityError
@@ -681,10 +682,16 @@ class DockerComposeManager:
                 logger.warning(f"Failed to clean up staged config directory: {e}")
 
     def get_container_diagnostics(self) -> str:
-        """Dump logs from all containers for diagnostic purposes.
+        """Dump logs and diagnostic information from all containers.
+
+        Captures:
+        - Container status and logs (last 200 lines)
+        - Docker stats (CPU/memory usage)
+        - Docker inspect (detailed state, restart count)
+        - Network reachability test for Home Assistant API
 
         Returns:
-            A string containing container status and logs for debugging.
+            A string containing container diagnostics for debugging.
         """
         logs = ["========== CONTAINER DIAGNOSTICS =========="]
         try:
@@ -693,6 +700,50 @@ class DockerComposeManager:
                 logs.append(f"{container}")
         except Exception as e:
             logs.append(f"** ERROR ** Failed to dump container diagnostics: {e}")
+
+        # Docker stats (CPU/memory usage)
+        try:
+            result = subprocess.run(
+                ["docker", "stats", "--no-stream", "--format", "table {{.Name}}\t{{.CPUPerc}}\t{{.MemUsage}}\t{{.MemPerc}}"],
+                cwd=self._containers_dir,
+                capture_output=True,
+                text=True,
+                check=True,
+            )
+            logs.append("\n========== DOCKER STATS ==========")
+            logs.append(result.stdout)
+        except Exception as e:
+            logs.append(f"\n** ERROR ** Failed to get docker stats: {e}")
+
+        # Docker inspect (detailed state, restart count)
+        try:
+            for container in self._containers.values():
+                result = subprocess.run(
+                    ["docker", "inspect", "--format", "{{.Name}}: State={{.State.Status}}, Restarts={{.RestartCount}}, ExitCode={{.State.ExitCode}}, OOMKilled={{.State.OOMKilled}}", container.container_id],
+                    capture_output=True,
+                    text=True,
+                    check=True,
+                )
+                logs.append(result.stdout.strip())
+        except Exception as e:
+            logs.append(f"** ERROR ** Failed to get docker inspect: {e}")
+
+        # Network reachability test for Home Assistant API
+        try:
+            ha_container = self._get_container("homeassistant")
+            if ha_container and ha_container.url:
+                logs.append("\n========== NETWORK REACHABILITY ==========")
+                try:
+                    response = requests.get(f"{ha_container.url}/api/", timeout=5)
+                    logs.append(f"Home Assistant API reachable: HTTP {response.status_code}")
+                except requests.Timeout:
+                    logs.append("Home Assistant API UNREACHABLE: Request timed out after 5s")
+                except requests.ConnectionError:
+                    logs.append("Home Assistant API UNREACHABLE: Connection refused")
+                except Exception as e:
+                    logs.append(f"Home Assistant API UNREACHABLE: {e}")
+        except Exception as e:
+            logs.append(f"** ERROR ** Failed to test network reachability: {e}")
 
         logs.append("========== END DIAGNOSTICS ==========")
         return "\n".join(logs)
@@ -893,7 +944,7 @@ class DockerComposeManager:
 
                 # Get container logs (no tail limit for stopped/failed containers)
                 logs_result = subprocess.run(
-                    ["docker", "logs", "--tail=100", container_id],
+                    ["docker", "logs", "--tail=200", container_id],
                     capture_output=True,
                     text=True,
                     encoding="utf-8",

--- a/src/ha_integration_test_harness/exceptions.py
+++ b/src/ha_integration_test_harness/exceptions.py
@@ -40,6 +40,22 @@ class HomeAssistantClientError(IntegrationTestError):
     pass
 
 
+class HomeAssistantTimeoutError(HomeAssistantClientError):
+    """Exception raised when a Home Assistant HTTP request times out.
+
+    This is a specialized exception for timeout failures, allowing callers
+    to distinguish between timeouts and other API errors. Inherits from
+    HomeAssistantClientError for backwards compatibility.
+
+    This includes failures in:
+    - HTTP request timeouts (GET, POST, DELETE)
+    - Socket timeouts
+    - Connection timeouts
+    """
+
+    pass
+
+
 class AppDaemonClientError(IntegrationTestError):
     """Exception raised when AppDaemon operations fail.
 

--- a/src/ha_integration_test_harness/homeassistant_client.py
+++ b/src/ha_integration_test_harness/homeassistant_client.py
@@ -59,6 +59,7 @@ class HomeAssistant:
             attributes: Optional dictionary of attributes to set for the entity.
 
         Raises:
+            HomeAssistantTimeoutError: If the request times out.
             HomeAssistantClientError: If the request fails due to network issues or API errors.
         """
         if entity_id in self._created_entities:
@@ -93,6 +94,7 @@ class HomeAssistant:
             The state dictionary of the entity, or None if not found (404 response).
 
         Raises:
+            HomeAssistantTimeoutError: If the request times out.
             HomeAssistantClientError: If the request fails due to network issues or API errors.
         """
         url = f"{self._base_url}/api/states/{entity_id}"
@@ -121,6 +123,7 @@ class HomeAssistant:
             ``latitude``, ``longitude``, and ``unit_system``.
 
         Raises:
+            HomeAssistantTimeoutError: If the request times out.
             HomeAssistantClientError: If the request fails due to network issues or API errors.
         """
         url = f"{self._base_url}/api/config"
@@ -265,6 +268,7 @@ class HomeAssistant:
             entity_id: The entity ID to remove (e.g., 'light.living_room').
 
         Raises:
+            HomeAssistantTimeoutError: If the request times out.
             HomeAssistantClientError: If the request fails due to network issues or API errors.
         """
         if entity_id in self._created_entities:
@@ -295,6 +299,7 @@ class HomeAssistant:
             data: Optional dictionary of action data (e.g., {'entity_id': 'light.living_room'}).
 
         Raises:
+            HomeAssistantTimeoutError: If the request times out.
             HomeAssistantClientError: If the request fails due to network issues or API errors.
         """
         url = f"{self._base_url}/api/services/{domain}/{action}"

--- a/src/ha_integration_test_harness/homeassistant_client.py
+++ b/src/ha_integration_test_harness/homeassistant_client.py
@@ -9,7 +9,7 @@ from urllib.parse import urlparse, urlunparse
 import requests
 import websocket
 
-from .exceptions import HomeAssistantClientError
+from .exceptions import HomeAssistantClientError, HomeAssistantTimeoutError
 
 logger = logging.getLogger(__name__)
 
@@ -26,15 +26,17 @@ class HomeAssistant:
     for authentication.
     """
 
-    def __init__(self, base_url: str, access_token: str) -> None:
+    def __init__(self, base_url: str, access_token: str, timeout: int = 10) -> None:
         """Initialize the Home Assistant client.
 
         Args:
             base_url: The base URL of the Home Assistant instance.
             access_token: The long-lived access token for authentication.
+            timeout: Default timeout in seconds for HTTP requests (default: 10).
         """
         self._base_url = base_url
         self._access_token = access_token
+        self._timeout = timeout
         self._created_entities: set[str] = set()
         self._entity_original_config: dict[str, dict[str, Any]] = {}
         self._known_area_ids: Optional[set[str]] = None
@@ -74,8 +76,10 @@ class HomeAssistant:
             body: dict[str, Any] = {"state": state}
             if attributes is not None:
                 body["attributes"] = attributes
-            response_http = requests.post(url, json=body, headers=headers)
+            response_http = requests.post(url, json=body, headers=headers, timeout=self._timeout)
             response_http.raise_for_status()
+        except requests.Timeout as e:
+            raise HomeAssistantTimeoutError(f"Home Assistant request timed out after {self._timeout}s: POST {url}: {e}")
         except requests.RequestException as e:
             raise HomeAssistantClientError(f"Failed to set state for entity {entity_id} at {url}: {e}")
 
@@ -94,7 +98,7 @@ class HomeAssistant:
         url = f"{self._base_url}/api/states/{entity_id}"
         try:
             headers = {"Authorization": f"Bearer {self._access_token}"}
-            response = requests.get(url, headers=headers)
+            response = requests.get(url, headers=headers, timeout=self._timeout)
 
             # 404 is acceptable - entity doesn't exist
             if response.status_code == 404:
@@ -103,6 +107,8 @@ class HomeAssistant:
             response.raise_for_status()
             result: dict[str, Any] = response.json()
             return result
+        except requests.Timeout as e:
+            raise HomeAssistantTimeoutError(f"Home Assistant request timed out after {self._timeout}s: GET {url}: {e}")
         except requests.RequestException as e:
             raise HomeAssistantClientError(f"Failed to get state for entity {entity_id} from {url}: {e}")
 
@@ -120,10 +126,12 @@ class HomeAssistant:
         url = f"{self._base_url}/api/config"
         try:
             headers = {"Authorization": f"Bearer {self._access_token}"}
-            response = requests.get(url, headers=headers)
+            response = requests.get(url, headers=headers, timeout=self._timeout)
             response.raise_for_status()
             result: dict[str, Any] = response.json()
             return result
+        except requests.Timeout as e:
+            raise HomeAssistantTimeoutError(f"Home Assistant request timed out after {self._timeout}s: GET {url}: {e}")
         except requests.RequestException as e:
             raise HomeAssistantClientError(f"Failed to fetch Home Assistant config from {url}: {e}")
 
@@ -269,10 +277,12 @@ class HomeAssistant:
         url = f"{self._base_url}/api/states/{entity_id}"
         try:
             headers = {"Authorization": f"Bearer {self._access_token}"}
-            response_http = requests.delete(url, headers=headers)
+            response_http = requests.delete(url, headers=headers, timeout=self._timeout)
             # 404 is acceptable - entity doesn't exist, which is the desired outcome
             if response_http.status_code != 404:
                 response_http.raise_for_status()
+        except requests.Timeout as e:
+            raise HomeAssistantTimeoutError(f"Home Assistant request timed out after {self._timeout}s: DELETE {url}: {e}")
         except requests.RequestException as e:
             raise HomeAssistantClientError(f"Failed to remove entity {entity_id} from {url}: {e}")
 
@@ -290,8 +300,10 @@ class HomeAssistant:
         url = f"{self._base_url}/api/services/{domain}/{action}"
         try:
             headers = {"Authorization": f"Bearer {self._access_token}"}
-            response = requests.post(url, json=data or {}, headers=headers)
+            response = requests.post(url, json=data or {}, headers=headers, timeout=self._timeout)
             response.raise_for_status()
+        except requests.Timeout as e:
+            raise HomeAssistantTimeoutError(f"Home Assistant request timed out after {self._timeout}s: POST {url}: {e}")
         except requests.RequestException as e:
             raise HomeAssistantClientError(f"Failed to call action {domain}.{action} at {url}: {e}")
 


### PR DESCRIPTION
## Summary

Adds request timeouts and enhanced diagnostics to address indefinite test hangs when the Home Assistant Docker container becomes unresponsive (issue #145).

## Changes

### Request Timeouts
- Added `timeout: int = 10` constructor parameter to `HomeAssistant` client
- Added `timeout=self._timeout` to all 5 HTTP methods (`set_state`, `get_state`, `get_config`, `remove_entity`, `call_action`)
- Catch `requests.Timeout` separately and raise `HomeAssistantTimeoutError` with method, URL, timeout value, and original exception

### New Exception Type
- Added `HomeAssistantTimeoutError(HomeAssistantClientError)` for timeout-specific handling
- Inherits from `HomeAssistantClientError` for backwards compatibility

### Enhanced Diagnostics (`get_container_diagnostics()`)
- `docker stats --no-stream` — CPU/memory usage per container
- `docker inspect` — restart count, detailed state, exit code, OOMKilled
- Network reachability test — HTTP probe to HA API with 5s timeout
- Log tail increased from 100 → 200 lines
- Added `test_name` and `test_duration` parameters for test context

### Docker Health Check
- Combined file-based + API-based check: `test -f /shared_data/.homeassistant_ready && curl -sf --max-time 2 http://localhost:8123/`
- File gate ensures setup completion (prevents premature healthy)
- curl probe detects mid-test unresponsiveness (healthy→unhealthy transition)

### Pytest Hook
- Extended `pytest_runtest_makereport` to detect `HomeAssistantTimeoutError`
- Captures diagnostics immediately on timeout (not deferred to session teardown)
- Stores docker manager in session stash for hook access

## Test Results
- 53 tests passed (all non-time-machine tests)
- 17 tests errored (pre-existing timezone issue in test_time_machine.py, unrelated to this change)
- Type checking passes (only pre-existing errors)

Closes #145