### PR TITLE
feat: add media_player.shuffle_set service call support

### DIFF
--- a/examples/test_media_player.py
+++ b/examples/test_media_player.py
@@ -239,6 +239,58 @@ class TestVolumeControls:
         home_assistant.assert_entity_state("media_player.test_speaker", "off")
 
 
+class TestShuffleControls:
+
+    def test_shuffle_set_true(self, home_assistant: HomeAssistant) -> None:
+        """Test that shuffle_set with True updates shuffle attribute."""
+        home_assistant.given_an_entity("media_player.test_speaker", "playing")
+
+        home_assistant.call_action(
+            "media_player",
+            "shuffle_set",
+            {"entity_id": "media_player.test_speaker", "shuffle": True},
+        )
+
+        home_assistant.assert_entity_state(
+            "media_player.test_speaker",
+            "playing",
+            expected_attributes={"shuffle": True},
+        )
+
+    def test_shuffle_set_false(self, home_assistant: HomeAssistant) -> None:
+        """Test that shuffle_set with False updates shuffle attribute."""
+        home_assistant.given_an_entity("media_player.test_speaker", "playing")
+        home_assistant.call_action(
+            "media_player",
+            "shuffle_set",
+            {"entity_id": "media_player.test_speaker", "shuffle": True},
+        )
+
+        home_assistant.call_action(
+            "media_player",
+            "shuffle_set",
+            {"entity_id": "media_player.test_speaker", "shuffle": False},
+        )
+
+        home_assistant.assert_entity_state(
+            "media_player.test_speaker",
+            "playing",
+            expected_attributes={"shuffle": False},
+        )
+
+    def test_shuffle_set_does_not_power_on(self, home_assistant: HomeAssistant) -> None:
+        """Test that shuffle_set does not auto-power-on the entity."""
+        home_assistant.given_an_entity("media_player.test_speaker", "off")
+
+        home_assistant.call_action(
+            "media_player",
+            "shuffle_set",
+            {"entity_id": "media_player.test_speaker", "shuffle": True},
+        )
+
+        home_assistant.assert_entity_state("media_player.test_speaker", "off")
+
+
 class TestEdgeCases:
 
     def test_media_play_when_off_is_noop(self, home_assistant: HomeAssistant) -> None:

--- a/src/ha_integration_test_harness/custom_components/ha_test_harness/entity.py
+++ b/src/ha_integration_test_harness/custom_components/ha_test_harness/entity.py
@@ -333,11 +333,11 @@ class VirtualLightEntity(LightEntity):
 
 
 class VirtualMediaPlayerEntity(MediaPlayerEntity):
-    """A virtual media player entity with programmatically controlled state.
+    """A virtual media player with programmatically controlled state.
 
     Supports turn_on/turn_off, playback transport (play_media, play, pause, stop,
-    play_pause, next_track, previous_track, seek), and volume (set, up, down, mute)
-    actions. State and attributes can be set directly via set_virtual_state().
+    play_pause, next_track, previous_track, seek), volume (set, up, down, mute),
+    and shuffle_set actions. State and attributes can be set directly via set_virtual_state().
     """
 
     _attr_should_poll = False
@@ -355,6 +355,7 @@ class VirtualMediaPlayerEntity(MediaPlayerEntity):
         | MediaPlayerEntityFeature.VOLUME_SET
         | MediaPlayerEntityFeature.VOLUME_STEP
         | MediaPlayerEntityFeature.VOLUME_MUTE
+        | MediaPlayerEntityFeature.SHUFFLE_SET
     )
 
     def __init__(self, unique_id: str, entity_id: str, state: str, attributes: dict[str, Any]) -> None:
@@ -382,6 +383,8 @@ class VirtualMediaPlayerEntity(MediaPlayerEntity):
             self._volume_level = float(attributes["volume_level"])
         if "is_volume_muted" in attributes:
             self._is_volume_muted = bool(attributes["is_volume_muted"])
+        if "shuffle" in attributes:
+            self._attr_shuffle = bool(attributes["shuffle"])
 
     @property
     def is_on(self) -> bool | None:
@@ -512,6 +515,11 @@ class VirtualMediaPlayerEntity(MediaPlayerEntity):
         self._is_volume_muted = mute
         self.async_write_ha_state()
 
+    async def async_set_shuffle(self, shuffle: bool) -> None:
+        """Enable or disable shuffle mode."""
+        self._attr_shuffle = shuffle
+        self.async_write_ha_state()
+
     def set_virtual_state(self, state: str, attributes: dict[str, Any] | None = None) -> None:
         """Update the entity state and optionally attributes, then push to HA.
 
@@ -535,6 +543,8 @@ class VirtualMediaPlayerEntity(MediaPlayerEntity):
                 self._volume_level = float(attributes["volume_level"])
             if "is_volume_muted" in attributes:
                 self._is_volume_muted = bool(attributes["is_volume_muted"])
+            if "shuffle" in attributes:
+                self._attr_shuffle = bool(attributes["shuffle"])
         self.async_write_ha_state()
 
 


### PR DESCRIPTION
## Summary

Adds support for mocking `media_player.shuffle_set` service calls on test entities.

## Changes

- Added `MediaPlayerEntityFeature.SHUFFLE_SET` to the supported features bitmask
- Implemented `async_set_shuffle()` handler to update shuffle state
- Added `shuffle` key sync in `set_virtual_state()` and `__init__()`
- Added 3 tests: set True, set False, no auto-power-on

## Verification

- All 73 tests pass
- mypy typechecking passes
- Pre-commit hooks pass

Closes #125