### PR TITLE
feat: add automatic rollback for set_state() after each test

### DIFF
--- a/examples/test_set_state_rollback.py
+++ b/examples/test_set_state_rollback.py
@@ -1,0 +1,170 @@
+"""Example tests demonstrating automatic rollback of set_state() after each test.
+
+This file demonstrates that state changes made via set_state() are automatically
+rolled back after each test, preventing state leakage between tests.
+
+Two scenarios are covered:
+
+1. Modifying existing entities:
+   - Entities defined in persistent_entities.yaml or created via given_an_entity()
+   - Their state is snapshot before the first set_state() call
+   - Restored to pre-test state after the test completes
+
+2. Creating new entities via set_state():
+   - Entities that don't exist before set_state() is called
+   - Automatically removed after the test completes
+"""
+
+from ha_integration_test_harness import HomeAssistant
+
+
+class TestSetStateRollbackForExistingEntities:
+    """Tests for rollback of state changes to existing entities."""
+
+    def test_set_state_modifies_persistent_entity(self, home_assistant: HomeAssistant) -> None:
+        """Test that set_state() can modify a persistent entity's state."""
+        # This entity is defined in persistent_entities.yaml with initial state "off"
+        entity_id = "light.living_room_lamp"
+
+        # Verify initial state
+        home_assistant.assert_entity_state(entity_id, "off")
+
+        # Modify the state
+        home_assistant.set_state(entity_id, "on", {"brightness": 255})
+
+        # Verify the state was modified
+        home_assistant.assert_entity_state(entity_id, "on", {"brightness": 255})
+
+    def test_persistent_entity_state_is_restored_after_modification(self, home_assistant: HomeAssistant) -> None:
+        """Test that persistent entity state is restored after the previous test."""
+        # This test runs after test_set_state_modifies_persistent_entity
+        # The entity should be back to its original state
+        entity_id = "light.living_room_lamp"
+
+        # Verify the entity is back to its original state (not "on" with brightness 255)
+        home_assistant.assert_entity_state(entity_id, "off")
+
+    def test_set_state_multiple_times_only_snapshots_once(self, home_assistant: HomeAssistant) -> None:
+        """Test that multiple set_state() calls only snapshot the original state once."""
+        entity_id = "switch.garage_door"
+
+        # Verify initial state
+        home_assistant.assert_entity_state(entity_id, "off")
+
+        # First set_state - should snapshot "off"
+        home_assistant.set_state(entity_id, "on")
+        home_assistant.assert_entity_state(entity_id, "on")
+
+        # Second set_state - should NOT snapshot "on", original is still "off"
+        home_assistant.set_state(entity_id, "on", {"power_consumption": 100})
+        home_assistant.assert_entity_state(entity_id, "on", {"power_consumption": 100})
+
+    def test_entity_restored_to_original_not_intermediate_state(self, home_assistant: HomeAssistant) -> None:
+        """Test that entity is restored to original state, not intermediate state."""
+        entity_id = "switch.garage_door"
+
+        # After the previous test, entity should be back to "off" (not "on" with power_consumption)
+        home_assistant.assert_entity_state(entity_id, "off")
+
+    def test_set_state_with_attributes_restores_both(self, home_assistant: HomeAssistant) -> None:
+        """Test that both state and attributes are restored."""
+        entity_id = "input_boolean.guest_mode"
+
+        # Verify initial state and attributes
+        home_assistant.assert_entity_state(entity_id, "off", {"icon": "mdi:account-group"})
+
+        # Modify both state and attributes
+        home_assistant.set_state(entity_id, "on", {"icon": "mdi:account-check", "friendly_name": "Guest Mode Active"})
+
+        # Verify modifications
+        home_assistant.assert_entity_state(entity_id, "on", {"icon": "mdi:account-check"})
+
+    def test_attributes_restored_after_modification(self, home_assistant: HomeAssistant) -> None:
+        """Test that attributes are restored to original values."""
+        entity_id = "input_boolean.guest_mode"
+
+        # Should be back to original state and attributes
+        home_assistant.assert_entity_state(entity_id, "off", {"icon": "mdi:account-group"})
+
+
+class TestSetStateRollbackForNewEntities:
+    """Tests for rollback of entities created via set_state()."""
+
+    def test_set_state_creates_new_entity(self, home_assistant: HomeAssistant) -> None:
+        """Test that set_state() can create a new entity that didn't exist before."""
+        entity_id = "sensor.test_temperature"
+
+        # Verify entity doesn't exist
+        assert home_assistant.get_state(entity_id) is None
+
+        # Create it via set_state
+        home_assistant.set_state(entity_id, "22.5", {"unit_of_measurement": "°C"})
+
+        # Verify it exists now
+        home_assistant.assert_entity_state(entity_id, "22.5", {"unit_of_measurement": "°C"})
+
+    def test_new_entity_removed_after_test(self, home_assistant: HomeAssistant) -> None:
+        """Test that entities created via set_state() are removed after the test."""
+        entity_id = "sensor.test_temperature"
+
+        # Entity should be gone after the previous test
+        assert home_assistant.get_state(entity_id) is None
+
+    def test_multiple_new_entities_all_removed(self, home_assistant: HomeAssistant) -> None:
+        """Test that multiple entities created via set_state() are all removed."""
+        entities = [
+            "sensor.new_entity_1",
+            "binary_sensor.new_entity_2",
+            "switch.new_entity_3",
+        ]
+
+        # Create multiple new entities
+        for entity_id in entities:
+            assert home_assistant.get_state(entity_id) is None
+            home_assistant.set_state(entity_id, "on")
+            home_assistant.assert_entity_state(entity_id, "on")
+
+    def test_all_new_entities_removed(self, home_assistant: HomeAssistant) -> None:
+        """Test that all entities created in the previous test are removed."""
+        entities = [
+            "sensor.new_entity_1",
+            "binary_sensor.new_entity_2",
+            "switch.new_entity_3",
+        ]
+
+        for entity_id in entities:
+            assert home_assistant.get_state(entity_id) is None
+
+
+class TestSetStateRollbackMixedScenarios:
+    """Tests for mixed scenarios with both existing and new entities."""
+
+    def test_mixed_existing_and_new_entities(self, home_assistant: HomeAssistant) -> None:
+        """Test rollback with both existing and new entities in the same test."""
+        existing_entity = "counter.doorbell_presses"
+        new_entity = "sensor.mixed_test_sensor"
+
+        # Verify initial states
+        home_assistant.assert_entity_state(existing_entity, "0")
+        assert home_assistant.get_state(new_entity) is None
+
+        # Modify existing entity
+        home_assistant.set_state(existing_entity, "5")
+
+        # Create new entity
+        home_assistant.set_state(new_entity, "100")
+
+        # Verify both changes
+        home_assistant.assert_entity_state(existing_entity, "5")
+        home_assistant.assert_entity_state(new_entity, "100")
+
+    def test_mixed_scenario_restored_correctly(self, home_assistant: HomeAssistant) -> None:
+        """Test that mixed scenario is restored correctly."""
+        existing_entity = "counter.doorbell_presses"
+        new_entity = "sensor.mixed_test_sensor"
+
+        # Existing entity should be restored
+        home_assistant.assert_entity_state(existing_entity, "0")
+
+        # New entity should be removed
+        assert home_assistant.get_state(new_entity) is None

--- a/src/ha_integration_test_harness/conftest.py
+++ b/src/ha_integration_test_harness/conftest.py
@@ -235,6 +235,8 @@ def _cleanup_test_entities(request: pytest.FixtureRequest) -> Generator[None, No
 
     - Calls ``restore_entity_config()`` to undo any label or area changes made via
       ``given_entity_has()`` during the test.
+    - Calls ``restore_entity_states()`` to undo any state changes made via
+      ``set_state()`` during the test.
     - Calls ``clean_up_test_entities()`` to remove any entities created via
       ``given_an_entity()``.
 
@@ -262,4 +264,7 @@ def _cleanup_test_entities(request: pytest.FixtureRequest) -> Generator[None, No
         try:
             home_assistant.restore_entity_config()
         finally:
-            home_assistant.clean_up_test_entities()
+            try:
+                home_assistant.restore_entity_states()
+            finally:
+                home_assistant.clean_up_test_entities()

--- a/src/ha_integration_test_harness/homeassistant_client.py
+++ b/src/ha_integration_test_harness/homeassistant_client.py
@@ -41,6 +41,7 @@ class HomeAssistant:
         self._timeout = timeout
         self._created_entities: set[str] = set()
         self._entity_original_config: dict[str, dict[str, Any]] = {}
+        self._entity_original_state: dict[str, Optional[dict[str, Any]]] = {}
         self._known_area_ids: Optional[set[str]] = None
         self._known_label_ids: Optional[set[str]] = None
         self._is_unresponsive: bool = False
@@ -65,6 +66,10 @@ class HomeAssistant:
         REST-injected entities are written only to the HA state machine — they are **not**
         registered in the entity registry and cannot be used with ``given_entity_has()``.
 
+        Before the first ``set_state()`` call per entity per test, the current state is
+        snapshot and will be automatically restored after the test completes. If the entity
+        didn't exist before ``set_state()`` was called, it will be removed at teardown.
+
         Args:
             entity_id: The entity ID to set the state for (e.g., 'light.living_room').
             state: The state value to set for the entity.
@@ -74,6 +79,9 @@ class HomeAssistant:
             HomeAssistantTimeoutError: If the request times out.
             HomeAssistantClientError: If the request fails due to network issues or API errors.
         """
+        if entity_id not in self._entity_original_state:
+            self._entity_original_state[entity_id] = self.get_state(entity_id)
+
         if entity_id in self._created_entities:
             payload: dict[str, Any] = {"id": 1, "type": "ha_test_harness/entity/set_state", "entity_id": entity_id, "state": state}
             if attributes is not None:
@@ -699,6 +707,72 @@ class HomeAssistant:
 
         if errors:
             raise HomeAssistantClientError(f"Failed to restore config for {len(errors)} entities:\n" + "\n".join(errors))
+
+    def restore_entity_states(self) -> None:
+        """Restore all entity states modified by set_state() to their original values.
+
+        This method is called automatically after each test function completes.
+        It restores both state and attributes for all entities modified via ``set_state()``.
+        If an entity didn't exist before ``set_state()`` was called (snapshot is None),
+        it is removed. Successfully restored/removed entities are cleared from tracking
+        immediately, while failed restorations remain tracked.
+
+        Raises:
+            HomeAssistantClientError: If any state restoration fails.
+        """
+        errors = []
+        successfully_restored = []
+
+        for entity_id, original_state in list(self._entity_original_state.items()):
+            try:
+                if original_state is None:
+                    self.remove_entity(entity_id)
+                else:
+                    state_value = original_state.get("state", "")
+                    attributes_value = original_state.get("attributes")
+                    self._restore_state_internal(entity_id, state_value, attributes_value)
+                successfully_restored.append(entity_id)
+            except HomeAssistantClientError as e:
+                errors.append(str(e))
+
+        for entity_id in successfully_restored:
+            del self._entity_original_state[entity_id]
+
+        if errors:
+            raise HomeAssistantClientError(f"Failed to restore state for {len(errors)} entities:\n" + "\n".join(errors))
+
+    def _restore_state_internal(self, entity_id: str, state: str, attributes: Optional[dict[str, Any]] = None) -> None:
+        """Internal method to restore entity state without triggering snapshot logic.
+
+        This bypasses the normal set_state() snapshot mechanism to avoid overwriting
+        the original state we're trying to restore to.
+
+        Args:
+            entity_id: The entity ID to restore state for.
+            state: The state value to restore.
+            attributes: Optional dictionary of attributes to restore.
+        """
+        if entity_id in self._created_entities:
+            payload: dict[str, Any] = {"id": 1, "type": "ha_test_harness/entity/set_state", "entity_id": entity_id, "state": state}
+            if attributes is not None:
+                payload["attributes"] = attributes
+            response = self._ws_send_receive(payload)
+            if not response.get("success"):
+                raise HomeAssistantClientError(f"Failed to restore state for entity {entity_id} via ha_test_harness: {response}")
+            return
+
+        url = f"{self._base_url}/api/states/{entity_id}"
+        try:
+            headers = {"Authorization": f"Bearer {self._access_token}"}
+            body: dict[str, Any] = {"state": state}
+            if attributes is not None:
+                body["attributes"] = attributes
+            response_http = requests.post(url, json=body, headers=headers, timeout=self._timeout)
+            response_http.raise_for_status()
+        except requests.Timeout as e:
+            raise HomeAssistantTimeoutError(f"Home Assistant request timed out after {self._timeout}s: POST {url}: {e}")
+        except requests.RequestException as e:
+            raise HomeAssistantClientError(f"Failed to restore state for entity {entity_id} at {url}: {e}")
 
     def clean_up_test_entities(self) -> None:
         """Remove all entities created via given_an_entity().

--- a/src/ha_integration_test_harness/homeassistant_client.py
+++ b/src/ha_integration_test_harness/homeassistant_client.py
@@ -82,6 +82,23 @@ class HomeAssistant:
         if entity_id not in self._entity_original_state:
             self._entity_original_state[entity_id] = self.get_state(entity_id)
 
+        self._apply_state(entity_id, state, attributes)
+
+    def _apply_state(self, entity_id: str, state: str, attributes: Optional[dict[str, Any]] = None) -> None:
+        """Apply state and/or attributes to an entity via the appropriate mechanism.
+
+        Routes the state update through WebSocket for entities created via ``given_an_entity()``
+        (to preserve entity registry registration), or through REST API for other entities.
+
+        Args:
+            entity_id: The entity ID to update.
+            state: The state value to set.
+            attributes: Optional dictionary of attributes to set.
+
+        Raises:
+            HomeAssistantTimeoutError: If the request times out.
+            HomeAssistantClientError: If the request fails.
+        """
         if entity_id in self._created_entities:
             payload: dict[str, Any] = {"id": 1, "type": "ha_test_harness/entity/set_state", "entity_id": entity_id, "state": state}
             if attributes is not None:
@@ -714,14 +731,13 @@ class HomeAssistant:
         This method is called automatically after each test function completes.
         It restores both state and attributes for all entities modified via ``set_state()``.
         If an entity didn't exist before ``set_state()`` was called (snapshot is None),
-        it is removed. Successfully restored/removed entities are cleared from tracking
-        immediately, while failed restorations remain tracked.
+        it is removed. Tracking is cleared regardless of success or failure to prevent
+        state pollution across tests.
 
         Raises:
             HomeAssistantClientError: If any state restoration fails.
         """
         errors = []
-        successfully_restored = []
 
         for entity_id, original_state in list(self._entity_original_state.items()):
             try:
@@ -730,49 +746,14 @@ class HomeAssistant:
                 else:
                     state_value = original_state.get("state", "")
                     attributes_value = original_state.get("attributes")
-                    self._restore_state_internal(entity_id, state_value, attributes_value)
-                successfully_restored.append(entity_id)
+                    self._apply_state(entity_id, state_value, attributes_value)
             except HomeAssistantClientError as e:
                 errors.append(str(e))
 
-        for entity_id in successfully_restored:
-            del self._entity_original_state[entity_id]
+        self._entity_original_state.clear()
 
         if errors:
             raise HomeAssistantClientError(f"Failed to restore state for {len(errors)} entities:\n" + "\n".join(errors))
-
-    def _restore_state_internal(self, entity_id: str, state: str, attributes: Optional[dict[str, Any]] = None) -> None:
-        """Internal method to restore entity state without triggering snapshot logic.
-
-        This bypasses the normal set_state() snapshot mechanism to avoid overwriting
-        the original state we're trying to restore to.
-
-        Args:
-            entity_id: The entity ID to restore state for.
-            state: The state value to restore.
-            attributes: Optional dictionary of attributes to restore.
-        """
-        if entity_id in self._created_entities:
-            payload: dict[str, Any] = {"id": 1, "type": "ha_test_harness/entity/set_state", "entity_id": entity_id, "state": state}
-            if attributes is not None:
-                payload["attributes"] = attributes
-            response = self._ws_send_receive(payload)
-            if not response.get("success"):
-                raise HomeAssistantClientError(f"Failed to restore state for entity {entity_id} via ha_test_harness: {response}")
-            return
-
-        url = f"{self._base_url}/api/states/{entity_id}"
-        try:
-            headers = {"Authorization": f"Bearer {self._access_token}"}
-            body: dict[str, Any] = {"state": state}
-            if attributes is not None:
-                body["attributes"] = attributes
-            response_http = requests.post(url, json=body, headers=headers, timeout=self._timeout)
-            response_http.raise_for_status()
-        except requests.Timeout as e:
-            raise HomeAssistantTimeoutError(f"Home Assistant request timed out after {self._timeout}s: POST {url}: {e}")
-        except requests.RequestException as e:
-            raise HomeAssistantClientError(f"Failed to restore state for entity {entity_id} at {url}: {e}")
 
     def clean_up_test_entities(self) -> None:
         """Remove all entities created via given_an_entity().


### PR DESCRIPTION
> ✨ AI-generated content. Mistakes do happen - please review carefully.

## Summary

Implements automatic rollback for `set_state()` calls to prevent state leakage between tests, as specified in #155.

## Changes

- **`homeassistant_client.py`**: Added state snapshotting before first `set_state()` call per entity per test, and `restore_entity_states()` method to restore states after test completion
- **`conftest.py`**: Wired `restore_entity_states()` into the cleanup fixture
- **`test_set_state_rollback.py`**: 12 comprehensive tests covering existing entities, new entities, and mixed scenarios

## Key Design Decisions

- Snapshot on first `set_state()` call per entity per test (follows pattern from `given_entity_has()` → `restore_entity_config()`)
- Clear tracking unconditionally after restore to prevent state pollution across tests
- Extracted `_apply_state()` helper to eliminate duplication between `set_state()` and restore logic
- Entities that didn't exist before `set_state()` are removed at teardown

## Test Results

- ✅ 12 new rollback tests pass
- ✅ 15 existing entity management tests pass
- ✅ 70 total tests pass (17 pre-existing tzdata errors in test_time_machine.py, unrelated to this feature)

## Spec Review

Code review identified and addressed three concerns:
1. **Failed restore pollution** - Fixed by clearing tracking unconditionally
2. **Error accumulation bug** - Fixed by same mechanism
3. **Fragile duplication** - Fixed by extracting `_apply_state()` helper

Closes #155