### PR TITLE
docs: add domain model documentation with CONTEXT.md and ADRs

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,74 @@
+# Home Assistant Integration Test Harness
+
+A pytest plugin that enables integration testing of Home Assistant configurations (automations, templates, scripts, custom entities) against a real but isolated HA instance running in Docker.
+
+## Language
+
+**Test harness**:
+The pytest plugin itself — the thing that orchestrates Docker, API clients, virtual entities, and time manipulation to enable testing against a real HA instance.
+_Avoid_: Test framework, test library
+
+**Virtual entity**:
+A fake entity registered with HA at runtime via websocket commands during test execution.
+Created programmatically per-test, destroyed after the test completes.
+Provides minimal implementation to satisfy test needs without mocking HA's entity system.
+_Avoid_: Mock entity, test entity, dynamic entity
+
+**Session-scoped entity**:
+An entity defined in YAML by the downstream project, registered with HA during startup (before HA comes online).
+Available to all tests in the session.
+Currently implemented as "persistent entities" via `ha_persistent_entities_path` config.
+_Avoid_: Persistent entity, pre-registered entity, bootstrap entity
+
+**Real entity**:
+An entity that exists in HA without the harness — from the user's production config, HA native entities (sun.sun, zone.home), or integration-provided entities.
+_Avoid_: Production entity, live entity
+
+**Configuration under test**:
+The Home Assistant configuration (YAML files for automations, templates, scripts, etc.) deployed into the HA instance.
+This is the combination of the downstream project's configuration files and the running HA instance that interprets them.
+_Avoid_: HA config, test subject, system under test
+
+**Injected state**:
+State set via `set_state()` on any entity (virtual or real). Automatically rolled back after each test to prevent state leakage.
+_Avoid_: Synthetic state, fake state, test state
+
+**Test rollback**:
+The automatic cleanup that occurs after each test. Virtual entities are destroyed; real and session-scoped entities have their state and config restored to pre-test values.
+_Avoid_: Cleanup, teardown, reset
+
+**Deploying configuration**:
+Copying HA config files (automations, templates, scripts, session-scoped entity definitions) into the Docker instance during startup, so HA reads them on initialization.
+_Avoid_: Deploying config, installing config, loading config
+
+**Dynamically registering virtual entities**:
+Creating virtual entities at runtime via websocket commands during test execution, as opposed to deploying configuration at startup.
+_Avoid_: Creating test entities, adding entities
+
+**Injecting state**:
+Setting entity state via `set_state()` on any entity (virtual or real). Automatically rolled back after each test.
+_Avoid_: Manipulating state, faking state, overriding state
+
+**Asserting entity state**:
+Verifying that an entity's state or attributes match expected values after triggering an action or deploying configuration.
+_Avoid_: Checking state, validating state, verifying state
+
+**Downstream project**:
+A project that consumes the test harness to validate its own Home Assistant configuration. Provides configuration files, session-scoped entity definitions, and test scenarios.
+_Aliases_: client project, test suite
+
+**Test environment**:
+The isolated execution context for tests — a Docker container running Home Assistant with deployed configuration. Created at session start, destroyed at session end.
+_Note_: Docker container is the infrastructure; HA instance is the application running inside it.
+
+## Design Principles
+
+**Test isolation**:
+Each test must be independent and not affected by other tests. This is achieved through Docker isolation (separate HA instance per test session) and automatic state rollback after each test.
+
+## Known Discrepancies
+
+- **persistent entities** vs **session-scoped entities**:
+  The code and config files use "persistent entities" (e.g., `ha_persistent_entities_path`),
+  but the domain term is "session-scoped entities".
+  This naming inconsistency should be addressed in a future refactor.

--- a/docs/adr/2026-06-automatic-state-rollback.md
+++ b/docs/adr/2026-06-automatic-state-rollback.md
@@ -1,0 +1,19 @@
+# Automatic state rollback
+
+> **Status:** Active
+> **Date:** 2026-06
+
+## Context
+
+Tests manipulate entity state and config to set up scenarios and verify behavior. Without cleanup, state changes leak between tests, causing instability and order-dependent failures.
+
+## Decision
+
+Automatically rollback all state and config changes after each test. Virtual entities are destroyed; real and pre-registered entities have their state and config restored to pre-test values.
+
+## Consequences
+
+- Tests are isolated and can run in any order
+- No need for manual cleanup in test code
+- Slight overhead from tracking and restoring state
+- Tests cannot rely on state persisting across tests

--- a/docs/adr/2026-06-docker-for-isolation.md
+++ b/docs/adr/2026-06-docker-for-isolation.md
@@ -1,0 +1,19 @@
+# Docker for isolation
+
+> **Status:** Active
+> **Date:** 2026-06
+
+## Context
+
+Integration tests for Home Assistant configurations need a real HA instance to validate automations, templates, scripts, and entity interactions. The alternative is mocking HA's behavior.
+
+## Decision
+
+Run HA in Docker containers to provide a real but isolated test environment. The Docker instance is ephemeral — created for the test session and destroyed after.
+
+## Consequences
+
+- Tests run against real HA behavior, not mocks
+- No risk of interfering with production HA instances
+- Tests require Docker to be available
+- Startup overhead from container creation

--- a/docs/adr/2026-06-websocket-for-virtual-entity-registration.md
+++ b/docs/adr/2026-06-websocket-for-virtual-entity-registration.md
@@ -1,0 +1,24 @@
+# Websocket for virtual entity registration
+
+> **Status:** Active
+> **Date:** 2026-06
+
+## Context
+
+Virtual entities need to be registered with HA at runtime during test execution. The alternative approaches include:
+
+- Modifying HA config files and restarting
+- Using HA's REST API (limited entity registration support)
+- Direct database manipulation
+
+## Decision
+
+Use HA's websocket API with a custom component to register virtual entities dynamically.
+The custom component exposes additional websocket commands that the test harness invokes to create and manage virtual entities.
+
+## Consequences
+
+- Entities can be created and destroyed per-test without restarting HA
+- No file I/O or restart overhead during tests
+- Requires shipping a custom component with the harness
+- Consumers don't need to understand the websocket mechanism


### PR DESCRIPTION
Adds domain model documentation capturing the project's language and key architectural decisions.

## Changes

- **CONTEXT.md**: Domain glossary with 12 terms covering entities (virtual, session-scoped, real), operations (deploying config, registering entities, injecting/asserting state, rollback), and infrastructure (test harness, test environment, downstream project, configuration under test). Includes design principle (test isolation) and known discrepancy (persistent vs session-scoped naming).

- **3 ADRs** in `docs/adr/`:
  - `2026-06-docker-for-isolation.md` — real HA in Docker vs mocking
  - `2026-06-automatic-state-rollback.md` — automatic cleanup after each test
  - `2026-06-websocket-for-virtual-entity-registration.md` — websocket + custom component vs config restart/REST API