### PR TITLE
fix: Clean up entity tracking after remove_entity()

### DIFF
--- a/examples/test_entity_management.py
+++ b/examples/test_entity_management.py
@@ -72,10 +72,10 @@ class TestEntitiesManagedByTests:
         assert home_assistant.get_state(sample_entity) is None
 
     def test_entity_created_modified_then_removed(self, home_assistant: HomeAssistant) -> None:
-        """Test that teardown succeeds when an entity is created, modified, then removed.
+        """Test that test rollback succeeds when an entity is created, modified, then removed.
 
         This reproduces issue #165: when a test creates an entity via given_an_entity(),
-        modifies it via set_state(), then removes it via remove_entity(), teardown should
+        modifies it via set_state(), then removes it via remove_entity(), test rollback should
         not attempt to restore state for the removed entity.
         """
         entity_id = "switch.test_create_modify_remove"
@@ -94,7 +94,7 @@ class TestEntitiesManagedByTests:
         # Confirm the entity no longer exists
         assert home_assistant.get_state(entity_id) is None
 
-        # Test passes, but teardown should not fail with "Entity not found" errors
+        # Test passes, but test rollback should not fail with "Entity not found" errors
 
 
 class TestEntitiesWithAreasAndLabels:

--- a/examples/test_entity_management.py
+++ b/examples/test_entity_management.py
@@ -71,6 +71,31 @@ class TestEntitiesManagedByTests:
         # Confirm the entity no longer exists in the state machine
         assert home_assistant.get_state(sample_entity) is None
 
+    def test_entity_created_modified_then_removed(self, home_assistant: HomeAssistant) -> None:
+        """Test that teardown succeeds when an entity is created, modified, then removed.
+
+        This reproduces issue #165: when a test creates an entity via given_an_entity(),
+        modifies it via set_state(), then removes it via remove_entity(), teardown should
+        not attempt to restore state for the removed entity.
+        """
+        entity_id = "switch.test_create_modify_remove"
+
+        # Create entity
+        home_assistant.given_an_entity(entity_id, state="off", attributes={"foo": "bar"})
+        home_assistant.assert_entity_state(entity_id, expected_state="off", expected_attributes={"foo": "bar"})
+
+        # Modify entity state
+        home_assistant.set_state(entity_id, state="on", attributes={"foo": "baz"})
+        home_assistant.assert_entity_state(entity_id, expected_state="on", expected_attributes={"foo": "baz"})
+
+        # Remove entity
+        home_assistant.remove_entity(entity_id)
+
+        # Confirm the entity no longer exists
+        assert home_assistant.get_state(entity_id) is None
+
+        # Test passes, but teardown should not fail with "Entity not found" errors
+
 
 class TestEntitiesWithAreasAndLabels:
 

--- a/src/ha_integration_test_harness/homeassistant_client.py
+++ b/src/ha_integration_test_harness/homeassistant_client.py
@@ -424,8 +424,7 @@ class HomeAssistant:
             response = self._ws_send_receive(payload)
             if not response.get("success"):
                 raise HomeAssistantClientError(f"Failed to remove entity {entity_id} via ha_test_harness: {response}")
-            self._created_entities.discard(entity_id)
-            self._entity_original_state.pop(entity_id, None)
+            self._forget_entity(entity_id)
             return
 
         url = f"{self._base_url}/api/states/{entity_id}"
@@ -435,12 +434,23 @@ class HomeAssistant:
             # 404 is acceptable - entity doesn't exist, which is the desired outcome
             if response_http.status_code != 404:
                 response_http.raise_for_status()
-            self._created_entities.discard(entity_id)
-            self._entity_original_state.pop(entity_id, None)
+            self._forget_entity(entity_id)
         except requests.Timeout as e:
             raise HomeAssistantTimeoutError(f"Home Assistant request timed out after {self._timeout}s: DELETE {url}: {e}")
         except requests.RequestException as e:
             raise HomeAssistantClientError(f"Failed to remove entity {entity_id} from {url}: {e}")
+
+    def _forget_entity(self, entity_id: str) -> None:
+        """Remove an entity from internal tracking dictionaries.
+
+        Called after successful entity removal to prevent test rollback from attempting
+        to restore state or clean up an entity that no longer exists.
+
+        Args:
+            entity_id: The entity ID to remove from tracking.
+        """
+        self._created_entities.discard(entity_id)
+        self._entity_original_state.pop(entity_id, None)
 
     def call_action(self, domain: str, action: str, data: Optional[dict[str, Any]] = None) -> None:
         """Call a Home Assistant action (service).

--- a/src/ha_integration_test_harness/homeassistant_client.py
+++ b/src/ha_integration_test_harness/homeassistant_client.py
@@ -424,6 +424,8 @@ class HomeAssistant:
             response = self._ws_send_receive(payload)
             if not response.get("success"):
                 raise HomeAssistantClientError(f"Failed to remove entity {entity_id} via ha_test_harness: {response}")
+            self._created_entities.discard(entity_id)
+            self._entity_original_state.pop(entity_id, None)
             return
 
         url = f"{self._base_url}/api/states/{entity_id}"
@@ -433,6 +435,8 @@ class HomeAssistant:
             # 404 is acceptable - entity doesn't exist, which is the desired outcome
             if response_http.status_code != 404:
                 response_http.raise_for_status()
+            self._created_entities.discard(entity_id)
+            self._entity_original_state.pop(entity_id, None)
         except requests.Timeout as e:
             raise HomeAssistantTimeoutError(f"Home Assistant request timed out after {self._timeout}s: DELETE {url}: {e}")
         except requests.RequestException as e:


### PR DESCRIPTION
## Summary

Fixes teardown failure when tests remove entities that were created via `given_an_entity()` and modified via `set_state()`.

## Changes

- `remove_entity()` now cleans up `_created_entities` and `_entity_original_state` after successful removal
- Added test covering create→modify→remove scenario

## Test Results

- All 103 tests pass
- Typechecking passes
- Pre-commit hooks pass

Closes #165